### PR TITLE
Tier 2: Shared utilities — config validator, column-shuffle fixes, D&C staging

### DIFF
--- a/scripts/column_shuf/column_shuffle_pipeline.py
+++ b/scripts/column_shuf/column_shuffle_pipeline.py
@@ -67,6 +67,8 @@ class GeneralConfig:
     sigmoid_steepness: float = 1.0
     min_sequence_separation: int = 10
     unique_pair_residue_range: Optional[List[int]] = None  # [start, end] to filter unique pairs, None = no filtering
+    state1_chain_id: str = "A"  # Chain ID for state1 PDB structure
+    state2_chain_id: str = "A"  # Chain ID for state2 PDB structure
 
 
 @dataclass
@@ -790,6 +792,12 @@ class ColumnShufflePipeline:
             analyzer = ProteinResidueInteractionAnalyzer(pdb_file)
         except Exception as e:
             self.logger.error(f"Failed to initialize interaction analyzer: {e}")
+            self.logger.warning(
+                f"FALLING BACK TO UNVALIDATED PAIRS for {state_name}. "
+                f"All {len(unique_pairs)} contact-map pairs will be used without "
+                f"interaction validation. Results may include pairs with no "
+                f"detectable non-bonded interactions."
+            )
             return unique_pairs, {}  # Return original pairs if analyzer fails
 
         # Analyze each pair
@@ -986,7 +994,7 @@ class ColumnShufflePipeline:
                 unique_pairs=unique_pairs_state1,
                 state_name=self.config.general.state1_name,
                 output_dir=output_dir,
-                chain_id='A'
+                chain_id=self.config.general.state1_chain_id
             )
 
             # Validate state2 pairs
@@ -995,7 +1003,7 @@ class ColumnShufflePipeline:
                 unique_pairs=unique_pairs_state2,
                 state_name=self.config.general.state2_name,
                 output_dir=output_dir,
-                chain_id='A'
+                chain_id=self.config.general.state2_chain_id
             )
 
             # Log validation summary
@@ -1023,16 +1031,40 @@ class ColumnShufflePipeline:
                 self.config.general.state2_name: unique_pairs_state2
             }
 
-            unique_pairs_dict_validated = {
-                self.config.general.state1_name: validated_pairs_state1,
-                self.config.general.state2_name: validated_pairs_state2
-            }
-
             with open(output_dir / "unique_pairs_raw.json", 'w') as f:
                 json.dump(unique_pairs_dict_raw, f, indent=2)
 
+            # Determine validation status for each state
+            # If validated pairs == raw pairs and no interaction details, validation failed/was skipped
+            state1_validated = (
+                validated_pairs_state1 != unique_pairs_state1
+                or bool(interaction_details_state1)
+            )
+            state2_validated = (
+                validated_pairs_state2 != unique_pairs_state2
+                or bool(interaction_details_state2)
+            )
+
+            if not state1_validated:
+                self.logger.warning(
+                    f"State1 ({self.config.general.state1_name}): Using UNVALIDATED pairs. "
+                    f"Interaction validation was not performed or failed."
+                )
+            if not state2_validated:
+                self.logger.warning(
+                    f"State2 ({self.config.general.state2_name}): Using UNVALIDATED pairs. "
+                    f"Interaction validation was not performed or failed."
+                )
+
             # Use validated pairs as the main unique_pairs.json for downstream analysis
-            unique_pairs_dict = unique_pairs_dict_validated
+            unique_pairs_dict = {
+                self.config.general.state1_name: validated_pairs_state1,
+                self.config.general.state2_name: validated_pairs_state2,
+                "validation_status": {
+                    self.config.general.state1_name: "validated" if state1_validated else "unvalidated",
+                    self.config.general.state2_name: "validated" if state2_validated else "unvalidated"
+                }
+            }
             with open(output_dir / "unique_pairs.json", 'w') as f:
                 json.dump(unique_pairs_dict, f, indent=2)
 

--- a/scripts/column_shuf/column_shuffle_pipeline.py
+++ b/scripts/column_shuf/column_shuffle_pipeline.py
@@ -1034,16 +1034,10 @@ class ColumnShufflePipeline:
             with open(output_dir / "unique_pairs_raw.json", 'w') as f:
                 json.dump(unique_pairs_dict_raw, f, indent=2)
 
-            # Determine validation status for each state
-            # If validated pairs == raw pairs and no interaction details, validation failed/was skipped
-            state1_validated = (
-                validated_pairs_state1 != unique_pairs_state1
-                or bool(interaction_details_state1)
-            )
-            state2_validated = (
-                validated_pairs_state2 != unique_pairs_state2
-                or bool(interaction_details_state2)
-            )
+            # Determine validation status: validated only if the validator
+            # actually returned non-empty results with interaction details
+            state1_validated = bool(validated_pairs_state1) and bool(interaction_details_state1)
+            state2_validated = bool(validated_pairs_state2) and bool(interaction_details_state2)
 
             if not state1_validated:
                 self.logger.warning(

--- a/scripts/column_shuf/example_config.yaml
+++ b/scripts/column_shuf/example_config.yaml
@@ -38,6 +38,10 @@ general:
   min_sequence_separation: 10  # Minimum residue separation for contact pairs
   unique_pair_residue_range: null  # Optional [start, end] range to filter unique pairs (e.g., [1, 100]), null = no filtering
 
+  # Chain IDs in PDB structures (used for interaction validation)
+  state1_chain_id: "A"  # Chain ID for state1 PDB (default: "A")
+  state2_chain_id: "A"  # Chain ID for state2 PDB (default: "A")
+
 # SLURM job submission configuration
 slurm:
   # Path to ColabFold conda environment

--- a/scripts/run_divide_and_conquer.py
+++ b/scripts/run_divide_and_conquer.py
@@ -188,6 +188,13 @@ class WorkflowOrchestrator:
             if file.is_file() and file.suffix.lower() not in ['.a3m', '.fasta', '.fas']:
                 staging_dir.mkdir(exist_ok=True)
                 dest = staging_dir / file.name
+                # Avoid overwriting previously staged files
+                if dest.exists():
+                    stem, suffix = file.stem, file.suffix
+                    counter = 1
+                    while dest.exists():
+                        dest = staging_dir / f"{stem}_{counter}{suffix}"
+                        counter += 1
                 self.logger.debug(f"Moving non-sequence file to staging: {file}")
                 file.rename(dest)
                 moved_files.append(str(file))
@@ -333,16 +340,18 @@ class WorkflowOrchestrator:
                     if os.path.isdir(item_path) and item.startswith('clade_'):
                         self.clade_dirs.append(item_path)
                     elif item.endswith('.a3m') and item.startswith('clade_'):
-                        # Handle case where clades are still A3M files, not directories
                         clade_name = os.path.splitext(item)[0]
                         clade_dir_path = os.path.join(clades_dir, clade_name)
-                        if not os.path.exists(clade_dir_path):
-                            os.makedirs(clade_dir_path)
-                            # Copy A3M file into directory (non-destructive)
-                            import shutil
-                            src_path = os.path.join(clades_dir, item)
-                            dst_path = os.path.join(clade_dir_path, item)
-                            shutil.copy2(src_path, dst_path)
+                        # Skip if directory already exists (already processed)
+                        if os.path.isdir(clade_dir_path):
+                            if clade_dir_path not in self.clade_dirs:
+                                self.clade_dirs.append(clade_dir_path)
+                            continue
+                        os.makedirs(clade_dir_path)
+                        import shutil
+                        src_path = os.path.join(clades_dir, item)
+                        dst_path = os.path.join(clade_dir_path, item)
+                        shutil.copy2(src_path, dst_path)
                         self.clade_dirs.append(clade_dir_path)
                 self.clade_dirs.sort()
                 self.logger.info(f"Loaded {len(self.clade_dirs)} clade directories")

--- a/scripts/run_divide_and_conquer.py
+++ b/scripts/run_divide_and_conquer.py
@@ -173,7 +173,7 @@ class WorkflowOrchestrator:
 
     def _clean_directory_for_colabfold(self, input_dir: str) -> None:
         """
-        Clean directory of non-A3M files before ColabFold submission.
+        Move non-A3M files to a .colabfold_staging subdir instead of deleting.
 
         Args:
             input_dir: Directory to clean
@@ -182,15 +182,18 @@ class WorkflowOrchestrator:
         if not input_path.is_dir():
             return
 
-        cleaned_files = []
+        staging_dir = input_path / '.colabfold_staging'
+        moved_files = []
         for file in input_path.iterdir():
             if file.is_file() and file.suffix.lower() not in ['.a3m', '.fasta', '.fas']:
-                self.logger.debug(f"Removing non-sequence file: {file}")
-                file.unlink(missing_ok=True)
-                cleaned_files.append(str(file))
+                staging_dir.mkdir(exist_ok=True)
+                dest = staging_dir / file.name
+                self.logger.debug(f"Moving non-sequence file to staging: {file}")
+                file.rename(dest)
+                moved_files.append(str(file))
 
-        if cleaned_files:
-            self.logger.info(f"Cleaned {len(cleaned_files)} non-sequence files from {input_dir}")
+        if moved_files:
+            self.logger.info(f"Staged {len(moved_files)} non-sequence files from {input_dir} to {staging_dir}")
     
     def step_4_structure_analysis(self) -> None:
         """Step 4: Multi-metric structure analysis."""
@@ -335,10 +338,11 @@ class WorkflowOrchestrator:
                         clade_dir_path = os.path.join(clades_dir, clade_name)
                         if not os.path.exists(clade_dir_path):
                             os.makedirs(clade_dir_path)
-                            # Move A3M file to directory
+                            # Copy A3M file into directory (non-destructive)
+                            import shutil
                             src_path = os.path.join(clades_dir, item)
                             dst_path = os.path.join(clade_dir_path, item)
-                            os.rename(src_path, dst_path)
+                            shutil.copy2(src_path, dst_path)
                         self.clade_dirs.append(clade_dir_path)
                 self.clade_dirs.sort()
                 self.logger.info(f"Loaded {len(self.clade_dirs)} clade directories")

--- a/src/af_claseq/utils/config_validator.py
+++ b/src/af_claseq/utils/config_validator.py
@@ -1,0 +1,120 @@
+"""Read-only preflight validator for AF_ClaSeq YAML configs."""
+
+import json, shutil, sys
+from pathlib import Path
+from typing import List
+import yaml
+from af_claseq.utils.logging_utils import get_logger
+
+logger = get_logger("config_validator")
+
+_PATH_KEYS = {
+    "source_a3m", "config_file", "structure_analysis_config",
+    "config_json", "default_pdb", "a3m_file", "fasttree_binary",
+    "m_fold_samp_input_a3m", "conda_env_path", "conda_env",
+}
+_JSON_CONFIG_KEYS = {"config_file", "structure_analysis_config", "config_json"}
+_METRIC_NAME_KEYS = {
+    "metric1_name", "metric2_name", "metric_name_1", "metric_name_2",
+    "impact_metric_name", "metric_name",
+}
+_SLURM_ACCOUNT_KEYS = {"slurm_account", "account"}
+_SLURM_PARTITION_KEYS = {"slurm_partition", "partition"}
+
+
+def _collect_values(data, target_keys):
+    """Recursively collect string values for *target_keys* from nested data."""
+    found = []
+    if isinstance(data, dict):
+        for k, v in data.items():
+            if k in target_keys and isinstance(v, str) and v:
+                found.append(v)
+            else:
+                found.extend(_collect_values(v, target_keys))
+    elif isinstance(data, list):
+        for item in data:
+            found.extend(_collect_values(item, target_keys))
+    return found
+
+def _all_metric_names_from_json(json_path: str) -> List[str]:
+    """Return every metric name defined in a structure-analysis JSON."""
+    with open(json_path, "r") as fh:
+        data = json.load(fh)
+    names = [c["name"] for c in data.get("filter_criteria", []) if "name" in c]
+    names += [c["name"] for c in data.get("composite_metrics", []) if "name" in c]
+    return names
+
+def validate_config(yaml_path: str) -> List[str]:
+    """Validate an AF_ClaSeq YAML config. Returns list of problems (empty = OK)."""
+    issues: List[str] = []
+    path = Path(yaml_path)
+
+    # 1. File exists and YAML parses
+    if not path.is_file():
+        return [f"Config file does not exist: {yaml_path}"]
+    try:
+        with open(path, "r") as fh:
+            cfg = yaml.safe_load(fh)
+    except yaml.YAMLError as exc:
+        return [f"YAML parse error: {exc}"]
+    if not isinstance(cfg, dict):
+        return ["YAML did not produce a top-level mapping"]
+
+    # 2. Required top-level section ('general' or 'input' for divide-and-conquer)
+    if "general" not in cfg and "input" not in cfg:
+        issues.append("Missing required top-level section: 'general' (or 'input')")
+
+    # 3. File-path existence and worktree check
+    for fp in _collect_values(cfg, _PATH_KEYS):
+        if ".worktrees/" in fp:
+            issues.append(f"Stale worktree reference in path: {fp}")
+        if not Path(fp).exists():
+            issues.append(f"Referenced path does not exist: {fp}")
+
+    # 4. JSON metric cross-reference
+    json_paths = _collect_values(cfg, _JSON_CONFIG_KEYS)
+    metric_names = _collect_values(cfg, _METRIC_NAME_KEYS)
+    plotting = cfg.get("plotting", {})
+    if isinstance(plotting, dict):
+        metric_names += plotting.get("metrics", []) or []
+        metric_names += plotting.get("metrics_to_plot", []) or []
+    for jp in json_paths:
+        if not Path(jp).is_file():
+            continue
+        available = _all_metric_names_from_json(jp)
+        for mn in metric_names:
+            if mn and mn not in available:
+                issues.append(f"Metric '{mn}' not found in {Path(jp).name}. Available: {available}")
+
+    # 5. External tools
+    _TMALIGN_SECTIONS = ("structure_analysis", "m_fold_sampling", "recompile_predict", "leave_one_out")
+    if any(s in cfg for s in _TMALIGN_SECTIONS) and shutil.which("TMalign") is None:
+        issues.append("TMalign not found on PATH (required by this workflow)")
+    if any(s in cfg for s in ("slurm", "colabfold", "structure_prediction")) and shutil.which("colabfold_batch") is None:
+        issues.append("colabfold_batch not found on PATH (may need conda activation)")
+
+    # 6. SLURM account / partition non-empty
+    for k, v in cfg.items():
+        if "slurm" not in k.lower() or not isinstance(v, dict):
+            continue
+        for key in _SLURM_ACCOUNT_KEYS | _SLURM_PARTITION_KEYS:
+            val = v.get(key)
+            if val is not None and not str(val).strip():
+                issues.append(f"SLURM '{key}' is empty")
+
+    return issues
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <config.yaml>")
+        sys.exit(2)
+
+    problems = validate_config(sys.argv[1])
+    if problems:
+        print(f"Found {len(problems)} issue(s):")
+        for i, msg in enumerate(problems, 1):
+            print(f"  {i}. {msg}")
+        sys.exit(1)
+    else:
+        print("Config OK -- no issues found.")

--- a/src/af_claseq/utils/config_validator.py
+++ b/src/af_claseq/utils/config_validator.py
@@ -12,6 +12,7 @@ _PATH_KEYS = {
     "source_a3m", "config_file", "structure_analysis_config",
     "config_json", "default_pdb", "a3m_file", "fasttree_binary",
     "m_fold_samp_input_a3m", "conda_env_path", "conda_env",
+    "state1_pdb", "state2_pdb", "state1_a3m", "state2_a3m",
 }
 _JSON_CONFIG_KEYS = {"config_file", "structure_analysis_config", "config_json"}
 _METRIC_NAME_KEYS = {


### PR DESCRIPTION
## Summary

Three shared utilities that all workflows benefit from.

### New: Config preflight validator (2B)
- src/af_claseq/utils/config_validator.py — read-only validation
- Checks: file existence, metric cross-ref, stale worktree paths, external tools, SLURM fields
- Covers column-shuffle state PDB/A3M paths

### Column-shuffle fixes (2C)
- Configurable state1_chain_id / state2_chain_id (was hardcoded 'A')
- Explicit validation_status in unique_pairs.json
- Correct status detection: requires non-empty results + interaction details

### D&C non-destructive execution (2D)
- Non-sequence files staged to .colabfold_staging instead of deleted
- Collision-safe staging (appends counter suffix)
- Resume skips already-processed clade directories (no duplicate processing)

### Codex review fixes (4 issues)
- Add column-shuffle path keys to validator
- Fix validation status false-positive when validator returns empty
- Prevent duplicate clade dirs on resume
- Collision-safe staging file names

Closes #35

## Test plan
- [x] Syntax verified for all files
- [x] Codex GPT-5.5 xhigh review — 4 issues found and fixed
- [ ] Manual run of validate_config on example configs