### PR TITLE
Fix redundant 3x PDB analysis in 2-metric plotting stage

### DIFF
--- a/scripts/run_m_fold_sampling_voting.py
+++ b/scripts/run_m_fold_sampling_voting.py
@@ -428,6 +428,8 @@ class AFClaSeqPipeline:
                     mbc = get_metric_bin_config(self.config.general, metric_name)
                     n_bins = mbc.compute_num_bins() if mbc is not None and mbc.bin_width is not None else 30
 
+                    metric_df = combined_df.dropna(subset=[metric_name])
+
                     plot_m_fold_sampling_1d(
                         results_dir=all_results_dirs,
                         metric_name=metric_name,
@@ -451,7 +453,7 @@ class AFClaSeqPipeline:
                         logger=self.logger,
                         metric_colors=metric_colors,
                         x_label=x_label,
-                        results_df=combined_df,
+                        results_df=metric_df,
                     )
 
                 self.logger.info(f"Generating 2D plot for combined criteria: {metric_names[0]} vs {metric_names[1]}")

--- a/scripts/run_m_fold_sampling_voting.py
+++ b/scripts/run_m_fold_sampling_voting.py
@@ -305,7 +305,8 @@ class AFClaSeqPipeline:
             # Import plotting functions directly
             from af_claseq.utils.plotting_manager import (
                 plot_m_fold_sampling_1d,
-                plot_m_fold_sampling_2d
+                plot_m_fold_sampling_2d,
+                load_results_df,
             )
 
             # Setup directories
@@ -388,20 +389,26 @@ class AFClaSeqPipeline:
                 )
 
             elif num_criteria == 2:
-                # Two criteria - generate both 1D plots for each criterion and 2D plots
                 self.logger.info("Two filter criteria detected - generating 1D plots for each criterion and 2D plots")
 
-                # Get metric names using the new explicit metric selection system
                 from af_claseq.m_fold_sampling_voting.config import get_selected_metrics
                 metric_names = get_selected_metrics(self.config.general)
-                
-                # Create metric colors dictionary mapping metric names to their colors
+
                 metric_colors = {
                     metric_names[0]: self.config.general.metric1_color,
                     metric_names[1]: self.config.general.metric2_color
                 }
 
-                # Generate 1D plots for each criterion
+                self.logger.info(f"Computing metrics for {metric_names} in a single pass")
+                combined_df = load_results_df(
+                    results_dir=all_results_dirs,
+                    metric_names=metric_names,
+                    csv_dir=str(csv_dir),
+                    config_file=self.config.general.config_file,
+                    plddt_threshold=self.config.m_fold_sampling.m_fold_plddt_threshold,
+                    logger=self.logger,
+                )
+
                 from af_claseq.m_fold_sampling_voting.config import get_metric_bin_config
                 for i, metric_name in enumerate(metric_names):
                     self.logger.info(f"Generating 1D plot for {metric_name}")
@@ -410,21 +417,16 @@ class AFClaSeqPipeline:
                         metric_max = self.config.m_fold_sampling.m_fold_metric1_max
                         metric_ticks = self.config.m_fold_sampling.m_fold_metric1_ticks
                         colors = self.config.general.metric1_color
+                        x_label = self.config.general.metric1_label or metric_name
                     else:
                         metric_min = self.config.m_fold_sampling.m_fold_metric2_min
                         metric_max = self.config.m_fold_sampling.m_fold_metric2_max
                         metric_ticks = self.config.m_fold_sampling.m_fold_metric2_ticks
                         colors = self.config.general.metric2_color
+                        x_label = self.config.general.metric2_label or metric_name
 
-                    # Use per-metric bin count from metric_bin_configs if available
                     mbc = get_metric_bin_config(self.config.general, metric_name)
                     n_bins = mbc.compute_num_bins() if mbc is not None and mbc.bin_width is not None else 30
-
-                    # Use custom label from config, fall back to metric name
-                    if i == 0:
-                        x_label = self.config.general.metric1_label or metric_name
-                    else:
-                        x_label = self.config.general.metric2_label or metric_name
 
                     plot_m_fold_sampling_1d(
                         results_dir=all_results_dirs,
@@ -449,9 +451,9 @@ class AFClaSeqPipeline:
                         logger=self.logger,
                         metric_colors=metric_colors,
                         x_label=x_label,
+                        results_df=combined_df,
                     )
 
-                # Generate 2D plot
                 self.logger.info(f"Generating 2D plot for combined criteria: {metric_names[0]} vs {metric_names[1]}")
                 plot_m_fold_sampling_2d(
                     results_dir=all_results_dirs,
@@ -470,6 +472,7 @@ class AFClaSeqPipeline:
                     logger=self.logger,
                     x_label=self.config.general.metric1_label,
                     y_label=self.config.general.metric2_label,
+                    results_df=combined_df,
                 )
 
             elif num_criteria > 2:

--- a/src/af_claseq/utils/plotting_manager.py
+++ b/src/af_claseq/utils/plotting_manager.py
@@ -739,10 +739,11 @@ def plot_m_fold_sampling_1d(
     logger: Optional[Any] = None,
     metric_colors: Optional[Dict[str, List[str]]] = None,
     x_label: Optional[str] = None,
+    results_df: Optional[pd.DataFrame] = None,
 ) -> List[str]:
     """
     Plot 1D sampling distribution for M-fold sampling metrics.
-    
+
     Args:
         results_dir: Directory or list of directories containing M-fold sampling results
         metric_name: Name of the metric to plot
@@ -764,21 +765,22 @@ def plot_m_fold_sampling_1d(
         figsize: Figure size (width, height)
         show_bin_lines: Show vertical lines at bin boundaries
         logger: Optional logger
-        
+        results_df: Pre-loaded DataFrame to skip metric computation (optional)
+
     Returns:
         List of paths to saved plots
     """
     log = logger or get_logger(__name__)
-    
-    # Load results DataFrame - now handling multiple directories
-    results_df = load_results_df(
-        results_dir=results_dir,
-        metric_names=[metric_name],
-        csv_dir=csv_dir,
-        config_file=config_file,
-        plddt_threshold=plddt_threshold,
-        logger=log
-    )
+
+    if results_df is None:
+        results_df = load_results_df(
+            results_dir=results_dir,
+            metric_names=[metric_name],
+            csv_dir=csv_dir,
+            config_file=config_file,
+            plddt_threshold=plddt_threshold,
+            logger=log
+        )
     
     # Check if metric-specific colors are provided
     if metric_colors and metric_name in metric_colors:
@@ -830,11 +832,12 @@ def plot_m_fold_sampling_2d(
     logger: Optional[Any] = None,
     x_label: Optional[str] = None,
     y_label: Optional[str] = None,
+    results_df: Optional[pd.DataFrame] = None,
 ) -> List[str]:
     """
     Plot 2D sampling distribution for M-fold sampling metrics.
-    
-    This function is a convenience wrapper around the more general plotting 
+
+    This function is a convenience wrapper around the more general plotting
     functions, specifically for M-fold sampling analysis.
 
     Args:
@@ -853,21 +856,22 @@ def plot_m_fold_sampling_2d(
         plddt_threshold: pLDDT threshold for filtering structures
         include_joint_plot: Whether to create joint plots with marginal distributions
         logger: Optional logger to use
-        
+        results_df: Pre-loaded DataFrame to skip metric computation (optional)
+
     Returns:
         List of paths to saved plots
     """
     log = logger or get_logger(__name__)
-    
-    # Load results DataFrame - now handling multiple directories
-    results_df = load_results_df(
-        results_dir=results_dir,
-        metric_names=[metric_name1, metric_name2],
-        csv_dir=csv_dir,
-        config_file=config_file,
-        plddt_threshold=plddt_threshold,
-        logger=log
-    )
+
+    if results_df is None:
+        results_df = load_results_df(
+            results_dir=results_dir,
+            metric_names=[metric_name1, metric_name2],
+            csv_dir=csv_dir,
+            config_file=config_file,
+            plddt_threshold=plddt_threshold,
+            logger=log
+        )
     
     # Sort by pLDDT to have points with higher pLDDT on top
     results_df = results_df.sort_values('plddt', ascending=True)


### PR DESCRIPTION
## Summary

- Fixes a performance bug where the `01_M_FOLD_SAMPLING_PLOT` stage scanned all PDB files **3 times** instead of 1 when 2 metrics are configured
- Added optional `results_df` parameter to `plot_m_fold_sampling_1d` and `plot_m_fold_sampling_2d` to accept pre-loaded DataFrames
- The 2-metric path in `plot_m_fold_sampling()` now calls `load_results_df` once with both metrics, then passes the combined DataFrame to all 3 plot calls

**Before:** metric1 PDB scan → metric2 PDB scan → metric1+metric2 PDB scan (3x wall time)
**After:** metric1+metric2 PDB scan → reuse DataFrame for all plots (1x wall time)

The single-metric path and all other callers are unaffected (new parameter defaults to `None`).

Closes #41

## Test plan

- [ ] Run a 2-metric config (e.g. ABL1 or GLP1R) — verify only 1 "Calculating metrics" log line appears instead of 3
- [ ] Verify all 3 plot types are still generated (two 1D + scatter/joint 2D)
- [ ] Verify CSV output: only `metric1_metric2_values.csv` is written (not separate per-metric CSVs)
- [ ] Confirm voting stage still reads from the combined CSV correctly
- [ ] Run a 1-metric config — verify no behavioral change