### PR TITLE
feat: add OpenFold (DeepSpeed+BF16) as a selectable prediction engine

### DIFF
--- a/example/config_examples/leave_one_out_config.yaml
+++ b/example/config_examples/leave_one_out_config.yaml
@@ -34,6 +34,13 @@ slurm:
   max_concurrent_jobs: 200  # Maximum simultaneous jobs
   num_models: 5     # Number of models per ColabFold prediction (required for LOO)
   num_seeds: 1      # Number of seeds per prediction
+  # --- Prediction engine (optional; default: colabfold) ---
+  prediction_engine: "colabfold"      # "colabfold" | "openfold"
+  # Used only when prediction_engine is "openfold":
+  openfold_config: "deepspeed_bf16"   # fastest verified config (~3.6x); see openfold_utils.OPENFOLD_CONFIGS
+  openfold_model: "model_3_ptm"
+  # openfold_conda_env: "/path/to/openfold2/conda/env"   # omit to use the built-in default
+  # openfold_dir: "/path/to/af-claseq-openfold/packages/openfold"   # omit to use the built-in default
 
 # Plotting and visualization settings
 plotting:

--- a/example/config_examples/m_fold_config.yaml
+++ b/example/config_examples/m_fold_config.yaml
@@ -36,6 +36,13 @@ slurm:
   slurm_time: "01:00:00"
   slurm_partition: "your_partition"
   max_workers: 200
+  # --- Prediction engine (optional; default: colabfold) ---
+  prediction_engine: "colabfold"      # "colabfold" | "openfold"
+  # Used only when prediction_engine is "openfold":
+  openfold_config: "deepspeed_bf16"   # fastest verified config (~3.6x); see openfold_utils.OPENFOLD_CONFIGS
+  openfold_model: "model_3_ptm"
+  # openfold_conda_env: "/path/to/openfold2/conda/env"   # omit to use the built-in default
+  # openfold_dir: "/path/to/af-claseq-openfold/packages/openfold"   # omit to use the built-in default
 
 # ============================================================================
 # PIPELINE CONTROL

--- a/example/config_examples/occurrence_voting.yaml
+++ b/example/config_examples/occurrence_voting.yaml
@@ -84,3 +84,10 @@ slurm:
   memory: "32G"         # Memory per job
   cpus: 8               # CPUs per job
   max_concurrent_jobs: 90  # Maximum simultaneous jobs
+  # --- Prediction engine (optional; default: colabfold) ---
+  prediction_engine: "colabfold"      # "colabfold" | "openfold"
+  # Used only when prediction_engine is "openfold":
+  openfold_config: "deepspeed_bf16"   # fastest verified config (~3.6x); see openfold_utils.OPENFOLD_CONFIGS
+  openfold_model: "model_3_ptm"
+  # openfold_conda_env: "/path/to/openfold2/conda/env"   # omit to use the built-in default
+  # openfold_dir: "/path/to/af-claseq-openfold/packages/openfold"   # omit to use the built-in default

--- a/scripts/run_m_fold_sampling_voting.py
+++ b/scripts/run_m_fold_sampling_voting.py
@@ -89,7 +89,12 @@ class AFClaSeqPipeline:
             check_interval=self.config.pipeline_control.check_interval,
             job_name_prefix=self.config.general.protein_name,
             num_models=self.config.general.num_models,
-            random_seed=self.config.general.random_seed
+            random_seed=self.config.general.random_seed,
+            prediction_engine=self.config.slurm.prediction_engine,
+            openfold_config=self.config.slurm.openfold_config,
+            openfold_model=self.config.slurm.openfold_model,
+            openfold_conda_env=self.config.slurm.openfold_conda_env,
+            openfold_dir=self.config.slurm.openfold_dir
         )
     
     def _create_directories(self) -> None:
@@ -726,6 +731,11 @@ class AFClaSeqPipeline:
                     'prediction_num_seed': self.config.recompile_predict.prediction_num_seed,
                     'check_interval': self.config.pipeline_control.check_interval,
                     'max_workers': self.config.slurm.max_workers,
+                    'prediction_engine': self.config.slurm.prediction_engine,
+                    'openfold_config': self.config.slurm.openfold_config,
+                    'openfold_model': self.config.slurm.openfold_model,
+                    'openfold_conda_env': self.config.slurm.openfold_conda_env,
+                    'openfold_dir': self.config.slurm.openfold_dir,
                     'job_name_prefix': f"{self.config.general.protein_name}_{criterion_name}"
                 }
                 

--- a/src/af_claseq/leave_one_out/config.py
+++ b/src/af_claseq/leave_one_out/config.py
@@ -59,6 +59,12 @@ class SlurmConfig:
     max_concurrent_jobs: int = 90
     num_models: int = 5  # Required for LOO analysis
     num_seeds: int = 1
+    # Prediction engine selection (defaults preserve existing ColabFold behaviour)
+    prediction_engine: str = "colabfold"        # "colabfold" | "openfold"
+    openfold_config: str = "deepspeed_bf16"      # see openfold_utils.OPENFOLD_CONFIGS
+    openfold_model: str = "model_3_ptm"
+    openfold_conda_env: Optional[str] = None     # None -> openfold_utils default (openfold2 env)
+    openfold_dir: Optional[str] = None           # None -> openfold_utils default
 
 
 @dataclass

--- a/src/af_claseq/leave_one_out/loo_workflow.py
+++ b/src/af_claseq/leave_one_out/loo_workflow.py
@@ -224,6 +224,11 @@ class LeaveOneOutManager:
             slurm_cpus_per_task=slurm_config.cpus,
             num_models=slurm_config.num_models,
             num_seeds=slurm_config.num_seeds,
+            prediction_engine=slurm_config.prediction_engine,
+            openfold_config=slurm_config.openfold_config,
+            openfold_model=slurm_config.openfold_model,
+            openfold_conda_env=slurm_config.openfold_conda_env,
+            openfold_dir=slurm_config.openfold_dir,
             job_name_prefix="loo"
         )
 

--- a/src/af_claseq/m_fold_sampling_voting/config.py
+++ b/src/af_claseq/m_fold_sampling_voting/config.py
@@ -79,6 +79,12 @@ class SlurmConfig:
     slurm_time: str
     slurm_partition: str
     max_workers: int
+    # Prediction engine selection (defaults preserve existing ColabFold behaviour)
+    prediction_engine: str = "colabfold"        # "colabfold" | "openfold"
+    openfold_config: str = "deepspeed_bf16"      # see openfold_utils.OPENFOLD_CONFIGS
+    openfold_model: str = "model_3_ptm"
+    openfold_conda_env: Optional[str] = None     # None -> openfold_utils default (openfold2 env)
+    openfold_dir: Optional[str] = None           # None -> openfold_utils default
 
 
 @dataclass

--- a/src/af_claseq/m_fold_sampling_voting/pure_seq_pred.py
+++ b/src/af_claseq/m_fold_sampling_voting/pure_seq_pred.py
@@ -85,7 +85,12 @@ class PureSequenceAF2Prediction:
             check_interval=self.config['check_interval'],
             job_name_prefix=job_prefix,
             prediction_num_model=self.config['prediction_num_model'],
-            prediction_num_seed=self.config['prediction_num_seed']
+            prediction_num_seed=self.config['prediction_num_seed'],
+            prediction_engine=self.config.get('prediction_engine', 'colabfold'),
+            openfold_config=self.config.get('openfold_config', 'deepspeed_bf16'),
+            openfold_model=self.config.get('openfold_model', 'model_3_ptm'),
+            openfold_conda_env=self.config.get('openfold_conda_env'),
+            openfold_dir=self.config.get('openfold_dir')
         )
         
     def collect_job_configs(self) -> Tuple[List[str], List[str], List[str]]:

--- a/src/af_claseq/occurrence_voting/config.py
+++ b/src/af_claseq/occurrence_voting/config.py
@@ -131,6 +131,12 @@ class SlurmConfig:
     memory: str = "32G"
     cpus: int = 8
     max_concurrent_jobs: int = 90
+    # Prediction engine selection (defaults preserve existing ColabFold behaviour)
+    prediction_engine: str = "colabfold"        # "colabfold" | "openfold"
+    openfold_config: str = "deepspeed_bf16"      # see openfold_utils.OPENFOLD_CONFIGS
+    openfold_model: str = "model_3_ptm"
+    openfold_conda_env: Optional[str] = None     # None -> openfold_utils default (openfold2 env)
+    openfold_dir: Optional[str] = None           # None -> openfold_utils default
 
 
 @dataclass

--- a/src/af_claseq/occurrence_voting/occurrence_voting.py
+++ b/src/af_claseq/occurrence_voting/occurrence_voting.py
@@ -83,6 +83,11 @@ class OccurrenceVotingManager:
             num_models=structure_config.num_models,
             num_seeds=structure_config.num_seeds,
             num_recycle=structure_config.num_recycle,
+            prediction_engine=slurm_config.prediction_engine,
+            openfold_config=slurm_config.openfold_config,
+            openfold_model=slurm_config.openfold_model,
+            openfold_conda_env=slurm_config.openfold_conda_env,
+            openfold_dir=slurm_config.openfold_dir,
             job_name_prefix="occ_vote"
         )
 

--- a/src/af_claseq/umap_voting/config.py
+++ b/src/af_claseq/umap_voting/config.py
@@ -259,6 +259,12 @@ class SlurmSection:
     gpus_per_task: int = 1
     cpus_per_task: int = 4
     check_interval: int = 60
+    # Prediction engine selection (defaults preserve existing ColabFold behaviour)
+    prediction_engine: str = "colabfold"        # "colabfold" | "openfold"
+    openfold_config: str = "deepspeed_bf16"      # see openfold_utils.OPENFOLD_CONFIGS
+    openfold_model: str = "model_3_ptm"
+    openfold_conda_env: str | None = None        # None -> openfold_utils default (openfold2 env)
+    openfold_dir: str | None = None              # None -> openfold_utils default
 
 
 @dataclass
@@ -333,6 +339,11 @@ class UmapVotingConfig:
                 gpus_per_task=sl.get("gpus_per_task", 1),
                 cpus_per_task=sl.get("cpus_per_task", 4),
                 check_interval=sl.get("check_interval", 60),
+                prediction_engine=sl.get("prediction_engine", "colabfold"),
+                openfold_config=sl.get("openfold_config", "deepspeed_bf16"),
+                openfold_model=sl.get("openfold_model", "model_3_ptm"),
+                openfold_conda_env=sl.get("openfold_conda_env"),
+                openfold_dir=sl.get("openfold_dir"),
             ),
             structure_analysis=StructureAnalysisSection.from_dict(sa, for_vae=False),
             plotting=PlottingSection(

--- a/src/af_claseq/umap_voting/predictor.py
+++ b/src/af_claseq/umap_voting/predictor.py
@@ -62,6 +62,11 @@ class Predictor:
             num_recycle=self.structure_prediction["num_recycle"],
             num_models=self.structure_prediction["num_models"],
             num_seeds=self.structure_prediction["num_seeds"],
+            prediction_engine=self.slurm.get("prediction_engine", "colabfold"),
+            openfold_config=self.slurm.get("openfold_config", "deepspeed_bf16"),
+            openfold_model=self.slurm.get("openfold_model", "model_3_ptm"),
+            openfold_conda_env=self.slurm.get("openfold_conda_env"),
+            openfold_dir=self.slurm.get("openfold_dir"),
         )
 
         a3ms = sorted(self.a3ms_dir.glob("bin_*.a3m"))

--- a/src/af_claseq/umap_voting/workflow.py
+++ b/src/af_claseq/umap_voting/workflow.py
@@ -125,6 +125,11 @@ class UmapVotingManager:
                 gpus_per_task=sl.gpus_per_task,
                 cpus_per_task=sl.cpus_per_task,
                 check_interval=sl.check_interval,
+                prediction_engine=sl.prediction_engine,
+                openfold_config=sl.openfold_config,
+                openfold_model=sl.openfold_model,
+                openfold_conda_env=sl.openfold_conda_env,
+                openfold_dir=sl.openfold_dir,
             ),
         )
         pred.run()

--- a/src/af_claseq/utils/openfold_utils.py
+++ b/src/af_claseq/utils/openfold_utils.py
@@ -1,0 +1,319 @@
+"""OpenFold prediction-engine helpers for AF_ClaSeq.
+
+This module contains the glue needed to run OpenFold as an alternative to ColabFold:
+converting a ColabFold-style ``task_dir`` (a folder of ``*.a3m`` MSAs) into OpenFold's
+batch input layout, building the ``run_pretrained_openfold.py`` command + its SLURM
+environment prelude, and collecting the resulting PDBs back under ColabFold's naming
+convention so the rest of the pipeline is untouched.
+
+Design notes
+------------
+* **No heavy imports.** Everything here is pure file I/O / string building (stdlib only),
+  so the module loads in the *driver* conda env (the one that has ``af_claseq``). The a3m
+  conversion and PDB collection run driver-side; only the inference itself runs inside the
+  SLURM job, in the isolated ``openfold2`` env (which deliberately does **not** contain
+  ``af_claseq``). This keeps the two dependency stacks separated.
+* **DeepSpeed + BF16 by default.** Benchmarked 3.6x faster than ColabFold on real ClaSeq
+  chunks at equivalent quality. See ``af-claseq-openfold/OPENFOLD_INTEGRATION.md``.
+* Paths are config-driven: the constants below are defaults that callers can override.
+"""
+
+import os
+import glob
+import shutil
+from typing import Dict, List, Optional, Tuple
+
+from af_claseq.utils.logging_utils import get_logger
+
+logger = get_logger("openfold_utils")
+
+
+# --- Default paths (overridable via config / SlurmJobSubmitter kwargs) ---------------
+DEFAULT_OPENFOLD_DIR = "/fs/ess/PAA0203/xing244/af-claseq-openfold/packages/openfold"
+DEFAULT_OPENFOLD_CONDA_ENV = "/fs/ess/PAA0203/xing244/.conda/envs/openfold2"
+
+# --- Verified OpenFold configurations ------------------------------------------------
+# Maps a config name -> the *extra* CLI flags for run_pretrained_openfold.py. The model
+# preset (``--config_preset``) is added separately so the engine config and the model
+# choice stay orthogonal. ``{flash_config}`` is substituted with a real JSON file path
+# (written into the work dir on demand) for the FlashAttention variants.
+OPENFOLD_CONFIGS: Dict[str, List[str]] = {
+    "default": ["--precision", "fp32"],
+    "deepspeed_bf16": ["--use_deepspeed_evoformer_attention", "--precision", "bf16"],
+    "deepspeed": ["--use_deepspeed_evoformer_attention"],
+    "bf16": ["--precision", "bf16"],
+    "flash_attention": ["--experiment_config_json", "{flash_config}"],
+    "bf16_flash": ["--precision", "bf16", "--experiment_config_json", "{flash_config}"],
+}
+
+DEFAULT_OPENFOLD_CONFIG = "deepspeed_bf16"
+DEFAULT_OPENFOLD_MODEL = "model_3_ptm"
+
+# Layout / sentinel constants
+OPENFOLD_WORK_DIRNAME = "_openfold_work"
+FLASH_CONFIG_CONTENT = '{"globals.use_flash": true}'
+# Minimal valid mmCIF data block. model_3_ptm is template-free, but the CLI parser still
+# requires the template dir to contain a file (real dir on disk is 11 bytes: "data_dummy\n").
+DUMMY_CIF_CONTENT = "data_dummy\n"
+
+
+def openfold_work_dir(task_dir: str) -> str:
+    """Return the per-task OpenFold scratch dir (lives inside ``task_dir``)."""
+    return os.path.join(task_dir, OPENFOLD_WORK_DIRNAME)
+
+
+def openfold_output_dir(task_dir: str) -> str:
+    """Return the OpenFold ``--output_dir`` for a task (inside the work dir)."""
+    return os.path.join(openfold_work_dir(task_dir), "output")
+
+
+def parse_query_from_a3m(a3m_path: str) -> str:
+    """Extract the ungapped query sequence (the first record) from an a3m file.
+
+    Skips comment (``#``) lines, takes the first ``>``-headed record, and strips alignment
+    gap characters (``-`` and ``.``). Mirrors the reference conversion in
+    ``af-claseq-openfold/scripts/05_chunk_msa.py``.
+    """
+    seq_parts: List[str] = []
+    in_query = False
+    with open(a3m_path) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith(">"):
+                if in_query:  # second header reached -> query record finished
+                    break
+                in_query = True
+                continue
+            if in_query:
+                seq_parts.append(line)
+    return "".join(seq_parts).replace("-", "").replace(".", "")
+
+
+def prepare_openfold_input(
+    task_dir: str,
+    work_dir: str,
+    openfold_config: str = DEFAULT_OPENFOLD_CONFIG,
+) -> Tuple[str, str, str]:
+    """Convert a ColabFold-style ``task_dir`` into OpenFold's batch input layout.
+
+    Creates, inside ``work_dir``:
+      ``fasta/``          one ``<tag>.fasta`` per a3m (ungapped query only)
+      ``alignments/<tag>/`` ``bfd_uniclust_hits.a3m`` (verbatim copy of the a3m) plus
+                          ``uniref90_hits.sto`` / ``mgnify_hits.sto`` query stubs
+      ``template_mmcif/`` a dummy template dir (required by the CLI, unused by model_3_ptm)
+
+    The conversion is a clean rebuild (idempotent across resubmissions). Returns
+    ``(fasta_dir, alignment_dir, template_dir)``.
+    """
+    fasta_dir = os.path.join(work_dir, "fasta")
+    alignment_dir = os.path.join(work_dir, "alignments")
+    template_dir = os.path.join(work_dir, "template_mmcif")
+    for d in (fasta_dir, alignment_dir, template_dir):
+        if os.path.exists(d):
+            shutil.rmtree(d)
+        os.makedirs(d)
+
+    a3m_files = sorted(f for f in os.listdir(task_dir) if f.endswith(".a3m"))
+    if not a3m_files:
+        raise FileNotFoundError(f"No .a3m files found in {task_dir}")
+
+    for a3m_name in a3m_files:
+        tag = os.path.splitext(a3m_name)[0]
+        a3m_path = os.path.join(task_dir, a3m_name)
+        query = parse_query_from_a3m(a3m_path)
+        if not query:
+            raise ValueError(f"Could not parse a query sequence from {a3m_path}")
+
+        with open(os.path.join(fasta_dir, f"{tag}.fasta"), "w") as fh:
+            fh.write(f">{tag}\n{query}\n")
+
+        tag_align_dir = os.path.join(alignment_dir, tag)
+        os.makedirs(tag_align_dir, exist_ok=True)
+        # Full a3m content -> the actual MSA OpenFold reads.
+        shutil.copyfile(a3m_path, os.path.join(tag_align_dir, "bfd_uniclust_hits.a3m"))
+        # Stockholm stubs MUST contain the query sequence (an empty .sto crashes OpenFold).
+        for stub in ("uniref90_hits.sto", "mgnify_hits.sto"):
+            with open(os.path.join(tag_align_dir, stub), "w") as fh:
+                fh.write(f"# STOCKHOLM 1.0\n{tag} {query}\n//\n")
+
+    with open(os.path.join(template_dir, "dummy.cif"), "w") as fh:
+        fh.write(DUMMY_CIF_CONTENT)
+
+    # FlashAttention variants need a real JSON file path.
+    if "flash" in openfold_config:
+        _write_flash_config(work_dir)
+
+    return fasta_dir, alignment_dir, template_dir
+
+
+def _write_flash_config(work_dir: str) -> str:
+    """Write the FlashAttention experiment-config JSON and return its path."""
+    path = os.path.join(work_dir, "flash_config.json")
+    os.makedirs(work_dir, exist_ok=True)
+    with open(path, "w") as fh:
+        fh.write(FLASH_CONFIG_CONTENT)
+    return path
+
+
+def build_openfold_command(
+    fasta_dir: str,
+    template_dir: str,
+    output_dir: str,
+    alignment_dir: str,
+    openfold_dir: str = DEFAULT_OPENFOLD_DIR,
+    openfold_config: str = DEFAULT_OPENFOLD_CONFIG,
+    openfold_model: str = DEFAULT_OPENFOLD_MODEL,
+    save_outputs: bool = False,
+    flash_config_path: Optional[str] = None,
+) -> str:
+    """Build the ``run_pretrained_openfold.py`` invocation (the part after the env setup).
+
+    ``save_outputs`` is off by default: the per-chunk output pickle is ~260 MB and the
+    pipeline only needs the PDB structure.
+    """
+    if openfold_config not in OPENFOLD_CONFIGS:
+        raise ValueError(
+            f"Unknown openfold_config '{openfold_config}'. "
+            f"Valid options: {sorted(OPENFOLD_CONFIGS)}"
+        )
+    if flash_config_path is None and "flash" in openfold_config:
+        flash_config_path = os.path.join(os.path.dirname(output_dir), "flash_config.json")
+
+    config_args = [
+        arg.replace("{flash_config}", flash_config_path or "")
+        for arg in OPENFOLD_CONFIGS[openfold_config]
+    ]
+
+    parts = [
+        "python",
+        os.path.join(openfold_dir, "run_pretrained_openfold.py"),
+        fasta_dir,
+        template_dir,
+        "--output_dir", output_dir,
+        "--use_precomputed_alignments", alignment_dir,
+        "--config_preset", openfold_model,
+        "--model_device", "cuda:0",
+        "--skip_relaxation",
+    ]
+    if save_outputs:
+        parts.append("--save_outputs")
+    parts.extend(config_args)
+    return " ".join(parts)
+
+
+def build_openfold_env_setup(
+    openfold_conda_env: str = DEFAULT_OPENFOLD_CONDA_ENV,
+    openfold_dir: str = DEFAULT_OPENFOLD_DIR,
+) -> str:
+    """Build the bash environment prelude for the OpenFold SLURM ``--wrap``.
+
+    Mirrors the proven benchmark setup, adapted to AF_ClaSeq's module conventions:
+    * ``set -eo pipefail`` only -- never ``set -u`` (conda's gcc activate script has an
+      unbound ``SYS_SYSROOT`` variable that would abort the job).
+    * no ``conda init`` (it rewrites ~/.bashrc non-atomically and has truncated this
+      user's ~/.bashrc under concurrent OSC jobs).
+    * ``CUTLASS_PATH`` is required by DeepSpeed's DS4Sci attention kernel.
+    * ``LD_LIBRARY_PATH`` must include ``$CONDA_PREFIX/lib`` for shared libraries.
+    * ``run_pretrained_openfold.py`` must be invoked from its source dir (it imports
+      local modules), hence the trailing ``cd``.
+    """
+    cue_ops_lib = os.path.join(
+        openfold_conda_env, "lib", "python3.10", "site-packages",
+        "cuequivariance_ops", "lib",
+    )
+    cutlass_path = os.path.join(openfold_dir, "cutlass")
+    return (
+        "set -eo pipefail && "
+        "module reset && module load cuda/12.4.1 miniconda3/24.1.2-py310 && "
+        f"conda activate {openfold_conda_env} && "
+        f"export CUTLASS_PATH={cutlass_path} && "
+        "export LIBRARY_PATH=$CONDA_PREFIX/lib:$LIBRARY_PATH && "
+        f"export LD_LIBRARY_PATH={cue_ops_lib}:$CONDA_PREFIX/lib:$LD_LIBRARY_PATH && "
+        f"cd {openfold_dir}"
+    )
+
+
+def build_openfold_wrap(
+    task_dir: str,
+    openfold_dir: str = DEFAULT_OPENFOLD_DIR,
+    openfold_conda_env: str = DEFAULT_OPENFOLD_CONDA_ENV,
+    openfold_config: str = DEFAULT_OPENFOLD_CONFIG,
+    openfold_model: str = DEFAULT_OPENFOLD_MODEL,
+    save_outputs: bool = False,
+) -> str:
+    """Prepare the OpenFold input for ``task_dir`` and return the full sbatch ``--wrap``.
+
+    This runs the a3m->OpenFold conversion *driver-side* (no torch needed) and returns the
+    ``"<env setup> && <python run_pretrained_openfold.py ...>"`` string to hand to sbatch.
+    """
+    work_dir = openfold_work_dir(task_dir)
+    fasta_dir, alignment_dir, template_dir = prepare_openfold_input(
+        task_dir, work_dir, openfold_config=openfold_config
+    )
+    output_dir = openfold_output_dir(task_dir)
+    os.makedirs(output_dir, exist_ok=True)
+    flash_config_path = (
+        os.path.join(work_dir, "flash_config.json") if "flash" in openfold_config else None
+    )
+    command = build_openfold_command(
+        fasta_dir=fasta_dir,
+        template_dir=template_dir,
+        output_dir=output_dir,
+        alignment_dir=alignment_dir,
+        openfold_dir=openfold_dir,
+        openfold_config=openfold_config,
+        openfold_model=openfold_model,
+        save_outputs=save_outputs,
+        flash_config_path=flash_config_path,
+    )
+    env_setup = build_openfold_env_setup(openfold_conda_env, openfold_dir)
+    return f"{env_setup} && {command}"
+
+
+def collect_openfold_output(
+    task_dir: str,
+    openfold_model: str = DEFAULT_OPENFOLD_MODEL,
+    seed: int = 0,
+) -> int:
+    """Copy OpenFold PDBs back into ``task_dir`` under ColabFold's naming convention.
+
+    OpenFold writes ``<output>/predictions/<tag>_<model>_unrelaxed.pdb``. Each is copied to
+    ``<task_dir>/<tag>_unrelaxed_rank_001_alphafold2_ptm_model_1_seed_<seed>.pdb`` so that
+    downstream code (which globs ``*.pdb`` and splits filenames on ``_unrelaxed``) finds the
+    structures unchanged. The ``seed`` suffix mirrors the submitter's configured random seed
+    (stages such as sequence_voting match on the exact seed). After copying, the entire work
+    dir is removed so the recursive ``*.pdb`` scans never see the raw (differently-named)
+    OpenFold outputs and double-count them.
+
+    Returns the number of PDBs collected.
+    """
+    work_dir = openfold_work_dir(task_dir)
+    output_dir = openfold_output_dir(task_dir)
+    suffix = f"_{openfold_model}_unrelaxed.pdb"
+    pdb_paths = sorted(
+        glob.glob(os.path.join(output_dir, "**", f"*{suffix}"), recursive=True)
+    )
+
+    collected = 0
+    for pdb_path in pdb_paths:
+        name = os.path.basename(pdb_path)
+        tag = name[: -len(suffix)] if name.endswith(suffix) else name.split("_unrelaxed")[0]
+        dest = os.path.join(
+            task_dir,
+            f"{tag}_unrelaxed_rank_001_alphafold2_ptm_model_1_seed_{seed:03d}.pdb",
+        )
+        shutil.copyfile(pdb_path, dest)
+        collected += 1
+
+    if os.path.exists(work_dir):
+        shutil.rmtree(work_dir, ignore_errors=True)
+    return collected
+
+
+def write_done_log(task_dir: str) -> None:
+    """Write the synthetic completion sentinel (ColabFold writes ``log.txt`` with 'Done';
+    OpenFold does not, so the pipeline's completion check needs us to emit it)."""
+    with open(os.path.join(task_dir, "log.txt"), "w") as fh:
+        fh.write("OpenFold prediction complete.\nDone\n")

--- a/src/af_claseq/utils/slurm_utils.py
+++ b/src/af_claseq/utils/slurm_utils.py
@@ -9,6 +9,7 @@ from enum import Enum
 from pathlib import Path
 
 from af_claseq.utils.logging_utils import get_logger
+from af_claseq.utils import openfold_utils
 
 # Initialize module logger
 logger = get_logger("slurm_utils")
@@ -56,6 +57,11 @@ class SlurmJobSubmitter:
         check_interval: int = 60,
         job_name_prefix: str = "fold",
         num_recycle: int = 3,
+        prediction_engine: str = "colabfold",
+        openfold_config: str = openfold_utils.DEFAULT_OPENFOLD_CONFIG,
+        openfold_model: str = openfold_utils.DEFAULT_OPENFOLD_MODEL,
+        openfold_conda_env: Optional[str] = None,
+        openfold_dir: Optional[str] = None,
         **kwargs
     ):
         """
@@ -82,6 +88,16 @@ class SlurmJobSubmitter:
                 For pure_pred mode:
                     - prediction_num_model (int): Number of models for prediction
                     - prediction_num_seed (int): Number of seeds for prediction
+            prediction_engine (str): "colabfold" (default) or "openfold".
+            openfold_config (str): OpenFold performance config when
+                prediction_engine="openfold" (default "deepspeed_bf16"). See
+                openfold_utils.OPENFOLD_CONFIGS for valid keys.
+            openfold_model (str): OpenFold config_preset (default "model_3_ptm").
+            openfold_conda_env (str): Conda env activated *inside* the OpenFold job
+                (default openfold_utils.DEFAULT_OPENFOLD_CONDA_ENV). Kept distinct from
+                conda_env_path, which stays the ColabFold env.
+            openfold_dir (str): OpenFold source dir (default
+                openfold_utils.DEFAULT_OPENFOLD_DIR).
         """
         # Basic SLURM configuration
         self.conda_env_path = conda_env_path
@@ -97,6 +113,28 @@ class SlurmJobSubmitter:
         self.check_interval = check_interval
         self.job_name_prefix = job_name_prefix
         self.num_recycle = num_recycle
+
+        # Prediction engine selection. All OpenFold parameters are defaulted, so existing
+        # ColabFold callers are unaffected. The OpenFold job runs in its own conda env
+        # (openfold_conda_env), keeping its dependency stack separate from af_claseq.
+        self.prediction_engine = (prediction_engine or "colabfold").lower()
+        if self.prediction_engine not in ("colabfold", "openfold"):
+            raise ValueError(
+                f"Invalid prediction_engine '{prediction_engine}'. "
+                "Choose 'colabfold' or 'openfold'."
+            )
+        self.openfold_config = openfold_config
+        self.openfold_model = openfold_model
+        self.openfold_conda_env = openfold_conda_env or openfold_utils.DEFAULT_OPENFOLD_CONDA_ENV
+        self.openfold_dir = openfold_dir or openfold_utils.DEFAULT_OPENFOLD_DIR
+        if (
+            self.prediction_engine == "openfold"
+            and self.openfold_config not in openfold_utils.OPENFOLD_CONFIGS
+        ):
+            raise ValueError(
+                f"Unknown openfold_config '{self.openfold_config}'. "
+                f"Valid options: {sorted(openfold_utils.OPENFOLD_CONFIGS)}"
+            )
 
         # Determine mode based on kwargs
         if any(k.startswith('prediction_') for k in kwargs):
@@ -134,6 +172,39 @@ class SlurmJobSubmitter:
                 config['random_seed'] = self.random_seed
             return config
 
+    def _build_colabfold_wrap(self, task_dir: str, config: Dict[str, int]) -> str:
+        """Build the ColabFold sbatch --wrap (env setup + colabfold_batch in/out=task_dir)."""
+        colabfold_cmd = [
+            "colabfold_batch",
+            "--num-recycle", str(self.num_recycle),
+            "--num-models", str(config['num_models']),
+            "--num-seeds", str(config['num_seeds']),
+        ]
+        if 'random_seed' in config:
+            colabfold_cmd.extend(["--random-seed", str(config['random_seed'])])
+        colabfold_cmd.extend([task_dir, task_dir])
+        colabfold_cmd = " ".join(colabfold_cmd)
+
+        # NOTE: the conda-init step was intentionally removed -- it rewrites ~/.bashrc
+        # non-atomically, and under concurrent OSC jobs (home shared across ascend+cardinal)
+        # it truncated this user's ~/.bashrc (lost aliases/exports/API keys). `module load
+        # miniconda3` already provides the conda shell function, so `conda activate` works.
+        env_setup = (
+            "module reset && module load cuda/12.4.1 miniconda3/24.1.2-py310 && "
+            f"conda activate {self.conda_env_path}"
+        )
+        return f"{env_setup} && {colabfold_cmd}"
+
+    def _build_openfold_wrap(self, task_dir: str) -> str:
+        """Prepare OpenFold input (driver-side) and build the OpenFold sbatch --wrap."""
+        return openfold_utils.build_openfold_wrap(
+            task_dir=task_dir,
+            openfold_dir=self.openfold_dir,
+            openfold_conda_env=self.openfold_conda_env,
+            openfold_config=self.openfold_config,
+            openfold_model=self.openfold_model,
+        )
+
     def submit_job(self, task_dir: str, job_id: str, job_type: Optional[str] = None) -> Optional[str]:
         """Submit a SLURM job for the given task directory."""
         if not os.path.exists(task_dir):
@@ -142,27 +213,13 @@ class SlurmJobSubmitter:
 
         config = self._get_job_config(job_type)
         
-        # Build colabfold command
-        colabfold_cmd = [
-            "colabfold_batch",
-            "--num-recycle", str(self.num_recycle),
-            "--num-models", str(config['num_models']),
-            "--num-seeds", str(config['num_seeds']),
-            # "--templates" , "--custom-template-path",
-            # "/fs/ess/PAA0203/xing244/AF_ClaSeq/results_updated/BCCIP/deepmsa_default/finalMSAs-alpha/template_test/template"
-        ]
-        
-        if 'random_seed' in config:
-            colabfold_cmd.extend(["--random-seed", str(config['random_seed'])])
-            
-        colabfold_cmd.extend([task_dir, task_dir])
-        colabfold_cmd = " ".join(colabfold_cmd)
-
-        # Build environment setup
-        env_setup = (
-            "module reset && module load cuda/12.4.1 miniconda3/24.1.2-py310 && "
-            f"conda init && conda activate {self.conda_env_path}"
-        )
+        # Build the prediction-engine command (the sbatch --wrap payload). For OpenFold the
+        # a3m->OpenFold input conversion happens here, driver-side -- only the inference runs
+        # inside the SLURM job (in the openfold2 env, which does not contain af_claseq).
+        if self.prediction_engine == "openfold":
+            wrap_command = self._build_openfold_wrap(task_dir)
+        else:
+            wrap_command = self._build_colabfold_wrap(task_dir, config)
 
         # Build sbatch command
         job_name = f"{self.job_name_prefix}_{job_id}"
@@ -179,7 +236,7 @@ class SlurmJobSubmitter:
             f"--time={self.slurm_time}",
             f"--partition={self.slurm_partition}",
             f"--gres=gpu:{self.slurm_gpus_per_task}",
-            "--wrap", f"{env_setup} && {colabfold_cmd}"
+            "--wrap", wrap_command
         ]
 
         job_type_str = f" ({job_type})" if job_type else ""
@@ -221,12 +278,35 @@ class SlurmJobSubmitter:
 
             self.wait_for_completion(current_job_id)
 
+            # OpenFold writes PDBs into its own work dir and no completion log; collect the
+            # structures back into task_dir (ColabFold naming) and emit the done sentinel.
+            if self.prediction_engine == "openfold":
+                self._collect_openfold(task_dir)
+
             if self._check_log_file(task_dir):
                 logger.info(f"All PDB files generated for {task_dir}")
                 break
             else:
                 logger.warning(f"PDB files missing in {task_dir}. Resubmitting job.")
                 self._backup_log_file(task_dir, current_job_id)
+
+    def _collect_openfold(self, task_dir: str) -> None:
+        """Collect OpenFold PDBs into task_dir (ColabFold naming) and write the done log.
+
+        The seed suffix mirrors the submitter's configured random seed so downstream stages
+        that match an exact filename (e.g. sequence_voting) find the structures. OpenFold
+        produces a single model_3_ptm structure per chunk (num_models/num_seeds, which are
+        ColabFold concepts, do not apply).
+        """
+        seed = getattr(self, 'random_seed', None) or 0
+        collected = openfold_utils.collect_openfold_output(
+            task_dir, openfold_model=self.openfold_model, seed=seed
+        )
+        if collected > 0:
+            openfold_utils.write_done_log(task_dir)
+            logger.info(f"Collected {collected} OpenFold PDB(s) into {task_dir}")
+        else:
+            logger.warning(f"No OpenFold PDBs found to collect for {task_dir}")
 
     def process_folders_concurrently(self, 
                                    folders: List[str], 

--- a/tests/test_engine_config_wiring.py
+++ b/tests/test_engine_config_wiring.py
@@ -1,0 +1,43 @@
+"""The prediction_engine + openfold options are exposed in every workflow's SLURM config
+section, default to ColabFold (backward compatible), and are settable to OpenFold."""
+
+
+def test_m_fold_slurm_config_engine_fields():
+    from af_claseq.m_fold_sampling_voting.config import SlurmConfig
+    base = dict(
+        conda_env_path="/e", slurm_account="A", slurm_output="/dev/null",
+        slurm_error="/dev/null", slurm_nodes=1, slurm_gpus_per_task=1, slurm_tasks=1,
+        slurm_cpus_per_task=8, slurm_time="01:00:00", slurm_partition="p", max_workers=10,
+    )
+    c = SlurmConfig(**base)
+    assert c.prediction_engine == "colabfold"
+    assert c.openfold_config == "deepspeed_bf16"
+    assert c.openfold_model == "model_3_ptm"
+    assert c.openfold_conda_env is None and c.openfold_dir is None
+    assert SlurmConfig(**base, prediction_engine="openfold").prediction_engine == "openfold"
+
+
+def test_loo_slurm_config_engine_fields():
+    from af_claseq.leave_one_out.config import SlurmConfig
+    c = SlurmConfig(conda_env_path="/e", account="A")
+    assert c.prediction_engine == "colabfold"
+    assert c.openfold_config == "deepspeed_bf16"
+    assert SlurmConfig(conda_env_path="/e", account="A",
+                       prediction_engine="openfold").prediction_engine == "openfold"
+
+
+def test_occurrence_slurm_config_engine_fields():
+    from af_claseq.occurrence_voting.config import SlurmConfig
+    c = SlurmConfig(conda_env_path="/e", account="A")
+    assert c.prediction_engine == "colabfold"
+    assert c.openfold_model == "model_3_ptm"
+    assert c.openfold_conda_env is None
+
+
+def test_umap_slurm_section_engine_fields():
+    from af_claseq.umap_voting.config import SlurmSection
+    c = SlurmSection(conda_env_path="/e", account="A")
+    assert c.prediction_engine == "colabfold"
+    assert c.openfold_conda_env is None
+    assert SlurmSection(conda_env_path="/e", account="A",
+                        openfold_config="bf16").openfold_config == "bf16"

--- a/tests/test_openfold_utils.py
+++ b/tests/test_openfold_utils.py
@@ -1,0 +1,209 @@
+"""Unit tests for the OpenFold prediction-engine helpers (pure file-I/O + command building).
+
+These run entirely driver-side -- no GPU, no SLURM, no torch -- exercising the a3m ->
+OpenFold conversion, the command/env construction, and the PDB collection/renaming.
+"""
+import os
+
+import pytest
+
+from af_claseq.utils import openfold_utils as ofu
+
+
+# --------------------------------------------------------------------------- helpers
+A3M_GROUP_1 = (
+    "#27\t1\n"
+    ">101\n"
+    "ACDEF---GHIKLMNPQR\n"
+    ">hitA\n"
+    "ACDEFxxxGHIKLMNPQR\n"
+    ">hitB\n"
+    "ACDEF---GHIKLMN.QR\n"
+)
+QUERY_1_UNGAPPED = "ACDEFGHIKLMNPQR"  # gaps ('-') stripped from the first record
+
+
+def _make_task_dir(tmp_path, a3m_map):
+    task_dir = tmp_path / "task"
+    task_dir.mkdir()
+    for name, content in a3m_map.items():
+        (task_dir / name).write_text(content)
+    return str(task_dir)
+
+
+# ------------------------------------------------------------------- parse_query_from_a3m
+def test_parse_query_strips_gaps_and_skips_comment(tmp_path):
+    p = tmp_path / "g.a3m"
+    p.write_text(A3M_GROUP_1)
+    assert ofu.parse_query_from_a3m(str(p)) == QUERY_1_UNGAPPED
+
+
+def test_parse_query_takes_only_first_record(tmp_path):
+    p = tmp_path / "g.a3m"
+    p.write_text(">q\nAAAA\n>other\nCCCCCCCC\n")
+    assert ofu.parse_query_from_a3m(str(p)) == "AAAA"
+
+
+def test_parse_query_strips_dots(tmp_path):
+    p = tmp_path / "g.a3m"
+    p.write_text(">q\nAC.DE.FG\n")
+    assert ofu.parse_query_from_a3m(str(p)) == "ACDEFG"
+
+
+# ------------------------------------------------------------------ prepare_openfold_input
+def test_prepare_openfold_input_layout_and_content(tmp_path):
+    task_dir = _make_task_dir(tmp_path, {"group_1.a3m": A3M_GROUP_1})
+    work_dir = str(tmp_path / "work")
+
+    fasta_dir, align_dir, template_dir = ofu.prepare_openfold_input(task_dir, work_dir)
+
+    # FASTA: header is the file stem, sequence is the ungapped query
+    fasta = os.path.join(fasta_dir, "group_1.fasta")
+    assert open(fasta).read() == f">group_1\n{QUERY_1_UNGAPPED}\n"
+
+    # bfd_uniclust_hits.a3m is a VERBATIM copy of the input a3m (all sequences preserved)
+    bfd = os.path.join(align_dir, "group_1", "bfd_uniclust_hits.a3m")
+    assert open(bfd).read() == A3M_GROUP_1
+
+    # Stockholm stubs contain the query (an empty .sto would crash OpenFold)
+    for stub in ("uniref90_hits.sto", "mgnify_hits.sto"):
+        sto = os.path.join(align_dir, "group_1", stub)
+        assert open(sto).read() == f"# STOCKHOLM 1.0\ngroup_1 {QUERY_1_UNGAPPED}\n//\n"
+
+    # dummy template file required by the CLI parser
+    assert os.path.isfile(os.path.join(template_dir, "dummy.cif"))
+
+
+def test_prepare_openfold_input_multiple_chunks(tmp_path):
+    task_dir = _make_task_dir(
+        tmp_path, {"a.a3m": ">a\nACDE\n>h\nACDE\n", "b.a3m": ">b\nWYWY\n"}
+    )
+    work_dir = str(tmp_path / "work")
+    fasta_dir, align_dir, _ = ofu.prepare_openfold_input(task_dir, work_dir)
+    assert os.path.isfile(os.path.join(fasta_dir, "a.fasta"))
+    assert os.path.isfile(os.path.join(fasta_dir, "b.fasta"))
+    assert os.path.isdir(os.path.join(align_dir, "a"))
+    assert os.path.isdir(os.path.join(align_dir, "b"))
+
+
+def test_prepare_openfold_input_is_clean_rebuild(tmp_path):
+    task_dir = _make_task_dir(tmp_path, {"a.a3m": ">a\nACDE\n"})
+    work_dir = str(tmp_path / "work")
+    ofu.prepare_openfold_input(task_dir, work_dir)
+    # a stale chunk from a previous run must not survive a rebuild
+    stale = os.path.join(work_dir, "fasta", "stale.fasta")
+    open(stale, "w").write("junk")
+    ofu.prepare_openfold_input(task_dir, work_dir)
+    assert not os.path.exists(stale)
+
+
+def test_prepare_openfold_input_no_a3m_raises(tmp_path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    with pytest.raises(FileNotFoundError):
+        ofu.prepare_openfold_input(str(empty), str(tmp_path / "work"))
+
+
+# ------------------------------------------------------------------- build_openfold_command
+def test_build_command_deepspeed_bf16_flags():
+    cmd = ofu.build_openfold_command(
+        "fa", "tmpl", "out", "align", openfold_dir="/of",
+        openfold_config="deepspeed_bf16", openfold_model="model_3_ptm",
+    )
+    assert "/of/run_pretrained_openfold.py" in cmd
+    assert cmd.split()[2:4] == ["fa", "tmpl"]  # positional fasta_dir, template_dir
+    assert "--output_dir out" in cmd
+    assert "--use_precomputed_alignments align" in cmd
+    assert "--config_preset model_3_ptm" in cmd
+    assert "--model_device cuda:0" in cmd
+    assert "--skip_relaxation" in cmd
+    assert "--use_deepspeed_evoformer_attention" in cmd
+    assert "--precision bf16" in cmd
+    assert "--save_outputs" not in cmd  # off by default (260 MB pkl/chunk)
+
+
+def test_build_command_save_outputs_toggle():
+    cmd = ofu.build_openfold_command("fa", "t", "o", "a", save_outputs=True)
+    assert "--save_outputs" in cmd
+
+
+def test_build_command_unknown_config_raises():
+    with pytest.raises(ValueError):
+        ofu.build_openfold_command("fa", "t", "o", "a", openfold_config="nope")
+
+
+def test_build_command_flash_substitutes_path():
+    cmd = ofu.build_openfold_command(
+        "fa", "t", "o", "a", openfold_config="bf16_flash",
+        flash_config_path="/w/flash_config.json",
+    )
+    assert "--experiment_config_json /w/flash_config.json" in cmd
+    assert "{flash_config}" not in cmd
+
+
+# ------------------------------------------------------------------- build_openfold_env_setup
+def test_env_setup_safety_invariants():
+    env = ofu.build_openfold_env_setup("/envs/openfold2", "/of")
+    assert "set -eo pipefail" in env
+    assert "conda init" not in env          # never: truncates ~/.bashrc under concurrent jobs
+    assert "set -u" not in env              # never: conda gcc activate has an unbound var
+    assert "conda activate /envs/openfold2" in env
+    assert "CUTLASS_PATH=/of/cutlass" in env
+    assert env.rstrip().endswith("cd /of")  # must run from the OpenFold source dir
+
+
+# ------------------------------------------------------------------- collect_openfold_output
+def _seed_openfold_pdb(task_dir, tag, model="model_3_ptm", content="ATOM  fake\n"):
+    pred_dir = os.path.join(ofu.openfold_output_dir(task_dir), "predictions")
+    os.makedirs(pred_dir, exist_ok=True)
+    path = os.path.join(pred_dir, f"{tag}_{model}_unrelaxed.pdb")
+    open(path, "w").write(content)
+    return path
+
+
+def test_collect_renames_to_colabfold_convention_with_seed(tmp_path):
+    task_dir = str(tmp_path / "task")
+    os.makedirs(task_dir)
+    _seed_openfold_pdb(task_dir, "group_1", content="ATOM  X\n")
+
+    n = ofu.collect_openfold_output(task_dir, seed=42)
+
+    assert n == 1
+    dest = os.path.join(
+        task_dir, "group_1_unrelaxed_rank_001_alphafold2_ptm_model_1_seed_042.pdb"
+    )
+    assert os.path.isfile(dest)
+    assert open(dest).read() == "ATOM  X\n"
+
+
+def test_collect_removes_work_dir_to_avoid_double_count(tmp_path):
+    task_dir = str(tmp_path / "task")
+    os.makedirs(task_dir)
+    _seed_openfold_pdb(task_dir, "g")
+    ofu.collect_openfold_output(task_dir)
+    # the raw OpenFold output tree must be gone so rglob('*.pdb') sees only the renamed copy
+    assert not os.path.exists(ofu.openfold_work_dir(task_dir))
+    remaining = [f for f in os.listdir(task_dir) if f.endswith(".pdb")]
+    assert remaining == ["g_unrelaxed_rank_001_alphafold2_ptm_model_1_seed_000.pdb"]
+
+
+def test_collect_handles_multiple_chunks(tmp_path):
+    task_dir = str(tmp_path / "task")
+    os.makedirs(task_dir)
+    for tag in ("group_1", "group_2", "group_3"):
+        _seed_openfold_pdb(task_dir, tag)
+    assert ofu.collect_openfold_output(task_dir) == 3
+
+
+def test_collect_no_outputs_returns_zero(tmp_path):
+    task_dir = str(tmp_path / "task")
+    os.makedirs(task_dir)
+    assert ofu.collect_openfold_output(task_dir) == 0
+
+
+# ------------------------------------------------------------------- write_done_log
+def test_write_done_log(tmp_path):
+    task_dir = str(tmp_path / "task")
+    os.makedirs(task_dir)
+    ofu.write_done_log(task_dir)
+    assert "Done" in open(os.path.join(task_dir, "log.txt")).read()

--- a/tests/test_slurm_engine.py
+++ b/tests/test_slurm_engine.py
@@ -1,0 +1,107 @@
+"""Tests for prediction-engine selection in SlurmJobSubmitter (colabfold | openfold).
+
+subprocess.run is mocked (no real sbatch) so we can assert on the generated --wrap payload.
+"""
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from af_claseq.utils.slurm_utils import SlurmJobSubmitter
+from af_claseq.utils import openfold_utils as ofu
+
+
+def _completed(stdout="Submitted batch job 12345"):
+    m = MagicMock()
+    m.stdout = stdout
+    m.returncode = 0
+    return m
+
+
+def _wrap_of(sbatch_cmd):
+    return sbatch_cmd[sbatch_cmd.index("--wrap") + 1]
+
+
+# ----------------------------------------------------------------- construction / validation
+def test_default_engine_is_colabfold():
+    s = SlurmJobSubmitter("/envs/cf", "A", num_models=1, num_seeds=1)
+    assert s.prediction_engine == "colabfold"
+
+
+def test_invalid_engine_raises():
+    with pytest.raises(ValueError):
+        SlurmJobSubmitter("/e", "A", prediction_engine="rosetta")
+
+
+def test_invalid_openfold_config_raises():
+    with pytest.raises(ValueError):
+        SlurmJobSubmitter("/e", "A", prediction_engine="openfold", openfold_config="bogus")
+
+
+def test_openfold_env_is_distinct_from_conda_env_path():
+    s = SlurmJobSubmitter("/envs/cf", "A", prediction_engine="openfold")
+    assert s.openfold_conda_env == ofu.DEFAULT_OPENFOLD_CONDA_ENV
+    assert s.conda_env_path == "/envs/cf"  # the ColabFold env is left untouched
+
+
+def test_openfold_paths_overridable():
+    s = SlurmJobSubmitter(
+        "/envs/cf", "A", prediction_engine="openfold",
+        openfold_conda_env="/custom/of2", openfold_dir="/custom/of",
+    )
+    assert s.openfold_conda_env == "/custom/of2"
+    assert s.openfold_dir == "/custom/of"
+
+
+# ----------------------------------------------------------------- colabfold submit (unchanged)
+def test_colabfold_submit_builds_colabfold_wrap(tmp_path):
+    task = tmp_path / "t"
+    task.mkdir()
+    (task / "g.a3m").write_text(">q\nACDE\n")
+    s = SlurmJobSubmitter("/envs/cf", "A", num_models=2, num_seeds=3)
+    with patch("af_claseq.utils.slurm_utils.subprocess.run", return_value=_completed()) as run:
+        jid = s.submit_job(str(task), "job0")
+    assert jid == "12345"
+    wrap = _wrap_of(run.call_args[0][0])
+    assert "colabfold_batch" in wrap
+    assert "conda activate /envs/cf" in wrap
+    assert f"{task} {task}" in wrap
+    assert "--num-models 2" in wrap and "--num-seeds 3" in wrap
+    assert "conda init" not in wrap  # the removed bugfix stays removed
+
+
+# ----------------------------------------------------------------- openfold submit
+def test_openfold_submit_builds_openfold_wrap_and_prepares_input(tmp_path):
+    task = tmp_path / "t"
+    task.mkdir()
+    (task / "group_1.a3m").write_text(">q\nACDEFGHIK\n>h\nACDEFGHIK\n")
+    s = SlurmJobSubmitter("/envs/cf", "A", num_models=1, num_seeds=1, prediction_engine="openfold")
+    with patch("af_claseq.utils.slurm_utils.subprocess.run", return_value=_completed()) as run:
+        jid = s.submit_job(str(task), "job0")
+    assert jid == "12345"
+    wrap = _wrap_of(run.call_args[0][0])
+    assert "run_pretrained_openfold.py" in wrap
+    assert f"conda activate {ofu.DEFAULT_OPENFOLD_CONDA_ENV}" in wrap
+    assert "set -eo pipefail" in wrap
+    assert "--use_deepspeed_evoformer_attention" in wrap and "--precision bf16" in wrap
+    assert "colabfold_batch" not in wrap
+    # driver-side a3m -> OpenFold conversion happened:
+    assert (task / "_openfold_work" / "fasta" / "group_1.fasta").exists()
+    assert (task / "_openfold_work" / "alignments" / "group_1" / "bfd_uniclust_hits.a3m").exists()
+
+
+def test_openfold_collect_renames_with_configured_seed(tmp_path):
+    task = tmp_path / "t"
+    task.mkdir()
+    s = SlurmJobSubmitter(
+        "/envs/cf", "A", num_models=1, num_seeds=1, random_seed=42, prediction_engine="openfold"
+    )
+    pred = task / "_openfold_work" / "output" / "predictions"
+    pred.mkdir(parents=True)
+    (pred / "group_1_model_3_ptm_unrelaxed.pdb").write_text("ATOM\n")
+
+    s._collect_openfold(str(task))
+
+    assert (task / "group_1_unrelaxed_rank_001_alphafold2_ptm_model_1_seed_042.pdb").exists()
+    assert "Done" in (task / "log.txt").read_text()
+    assert not (task / "_openfold_work").exists()


### PR DESCRIPTION
## Summary

Adds **OpenFold** as a selectable structure-prediction engine alongside **ColabFold**, chosen via `prediction_engine` in the `slurm:` config section. OpenFold runs the verified **DeepSpeed + BF16** configuration — benchmarked **~3.6× faster** than ColabFold on real ClaSeq chunks at equivalent quality (A-loop CA-RMSD within 0.1 Å; pLDDT ~87 vs ~84).

Closes #47.

## How it works

```yaml
slurm:
  conda_env_path: ".../envs/colabfold"   # driver + ColabFold env (unchanged)
  prediction_engine: "openfold"          # NEW — "colabfold" (default) | "openfold"
  openfold_config: "deepspeed_bf16"      # NEW — fastest verified config
```

- **Driver-side** (the env that has `af_claseq`): a3m→OpenFold input conversion and PDB collection (pure file-I/O, no torch).
- **Inside the SLURM job**: only `run_pretrained_openfold.py` runs, in the isolated `openfold2` env (torch / deepspeed / flash-attn / openfold; **no** `af_claseq`). ColabFold jobs still activate the `colabfold` env. Flipping `prediction_engine` auto-selects the right job env via a dedicated `openfold_conda_env` — `conda_env_path` is left untouched.

## Changes

**Core**
- `src/af_claseq/utils/openfold_utils.py` (new) — `prepare_openfold_input` (a3m → `fasta/` + `alignments/<tag>/` + dummy template), `build_openfold_command` / `build_openfold_env_setup` / `build_openfold_wrap`, `collect_openfold_output` (renames PDBs to the ColabFold convention with the configured seed, then removes the work dir so recursive `*.pdb` scans don't double-count), `write_done_log`. Includes `OPENFOLD_CONFIGS` and overridable default paths.
- `src/af_claseq/utils/slurm_utils.py` — new fully-defaulted params (`prediction_engine`, `openfold_config`, `openfold_model`, `openfold_conda_env`, `openfold_dir`); `submit_job` branches per engine; `process_folder` collects OpenFold output and writes the synthetic completion log. The ColabFold path is factored into `_build_colabfold_wrap` (the `conda init` removal fix is preserved there).

**Config wiring (all 4 workflows)** — `prediction_engine` + OpenFold options added to the `slurm:` section of `m_fold_sampling_voting`, `leave_one_out`, `occurrence_voting`, `umap_voting`, and their example YAMLs. Every default keeps existing ColabFold behaviour.

## Backward compatibility

`prediction_engine` defaults to `"colabfold"` and every new param/field is defaulted, so existing configs and callers are unaffected.

## Notes / limitations

- OpenFold mode produces **one `model_3_ptm` structure per chunk** (`num_models`/`num_seeds` are ColabFold concepts). Best suited to the sampling/voting stages; stages relying on a 5×8 ensemble should keep ColabFold.
- `--save_outputs` is omitted (skips the ~260 MB pkl/chunk; only the PDB is needed downstream).
- Default OpenFold paths point at the user's `af-claseq-openfold/` install but are overridable in YAML for portability.

## Testing

29 new tests (`tests/test_openfold_utils.py`, `tests/test_slurm_engine.py`, `tests/test_engine_config_wiring.py`) cover the a3m→OpenFold conversion, command/env building, PDB collection + seed-aware renaming, engine selection/validation in the submitter, and the config-field wiring across all 4 workflows.

`pytest` reports **68 passed** for the whole suite except two pre-existing CPU-heavy numerical files — `umap_voting/test_vae_train.py` and `umap_voting/test_projector.py` — which run real VAE training / UMAP projection, exceed ~5 min here, and import none of the changed code. The umap `test_predictor.py` and `test_workflow_smoke.py` (which exercise the changed predictor/workflow wiring) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRYthRXcyXqDmp9j8Zxnvv
