### PR TITLE
feat(m_fold): select recompile bins by structural-metric threshold (closes #49)

### DIFF
--- a/example/config_examples/m_fold_config.yaml
+++ b/example/config_examples/m_fold_config.yaml
@@ -101,11 +101,22 @@ sequence_voting:
 # STAGE 03: RECOMPILE & PREDICTION CONFIGURATION
 # ============================================================================
 recompile_predict:
-  # Bin selection for recompilation
+  # --- Bin selection: choose ONE mode per metric ---
+  # Mode A (default, explicit bins): list the bin indices to recompile.
   bin_numbers_1: [26]        # Bin numbers for first metric
-  bin_numbers_2: [9]        # Bin numbers for second metric (if applicable)
-  combine_bins: false            # Whether to combine bins
-  
+  bin_numbers_2: [9]         # Bin numbers for second metric (if applicable)
+  combine_bins: false        # Whether to union bin_numbers_* into one prediction set
+
+  # Mode B (metric threshold): set threshold_N + threshold_direction_N to auto-select
+  # every bin whose ENTIRE range is on the reference side of the cutoff, pooled into one
+  # combined set named bin_<i>_<j>_.... Overrides bin_numbers_N for that metric.
+  # Direction is explicit: "below" (RMSD-/distance-like) or "above" (TM-/distance-like).
+  # Requires general.metric_bin_configs[<metric>] (bin_width/min/max). Examples:
+  # threshold_1: 0.9              # e.g. TM-score >= 0.9
+  # threshold_direction_1: "above"
+  # threshold_2: 2.0              # e.g. RMSD <= 2.0 A
+  # threshold_direction_2: "below"
+
   # Metric mapping (should match filter criteria names)
   metric_name_1: "2qke_tmscore"     # Name of first metric
   metric_name_2: "5jyt_tmscore"            # Name of second metric (if using two criteria)

--- a/scripts/run_m_fold_sampling_voting.py
+++ b/scripts/run_m_fold_sampling_voting.py
@@ -13,7 +13,7 @@ import json
 import numpy as np
 import pandas as pd
 from pathlib import Path
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional, Tuple
 
 # Import modules from AF-ClaSeq
 from af_claseq.utils.slurm_utils import SlurmJobSubmitter
@@ -26,7 +26,7 @@ from af_claseq.m_fold_sampling_voting.pure_seq_pred import PureSequenceAF2Predic
 from af_claseq.m_fold_sampling_voting.pure_seq_plot import PureSequencePlotter, create_pure_seq_plot_config_from_dict
 from af_claseq.utils.logging_utils import setup_logger 
 
-from af_claseq.m_fold_sampling_voting.config import load_pipeline_config
+from af_claseq.m_fold_sampling_voting.config import load_pipeline_config, MetricBinConfig
 
 
 class AFClaSeqPipeline:
@@ -47,7 +47,11 @@ class AFClaSeqPipeline:
         
         # Load filter configuration
         self.filter_config = self._load_filter_config()
-        
+
+        # Warn (do not error) if the deprecated above/below 'method' field is present in
+        # the structure-analysis JSON — the m-fold workflow no longer uses it.
+        self._warn_deprecated_method_field()
+
     def _setup_logging(self) -> logging.Logger:
         """Set up logging configuration"""
         # Use base_dir directly as specified in config
@@ -72,7 +76,33 @@ class AFClaSeqPipeline:
         """Load filter configuration from JSON file"""
         with open(self.config.general.config_file, 'r') as f:
             return json.load(f)
-    
+
+    def _warn_deprecated_method_field(self) -> None:
+        """Emit a one-time deprecation notice if any filter criterion still carries the
+        legacy above/below ``method`` key.
+
+        The m-fold sampling/voting workflow no longer uses it (recompile direction is now
+        set explicitly via ``recompile_predict.threshold_direction_*``), so it is ignored
+        here. The pipeline continues normally — this is a reminder, not an error.
+
+        Note: ``method`` is still used by the divide_and_conquer workflow
+        (``structure_analysis.apply_filters``) and by the legacy ``method == 'all_atom_rmsd'``
+        type alias, so it is NOT removed and only the above/below values are flagged.
+        """
+        flagged = [
+            c.get('name', '<unnamed>')
+            for c in self.filter_config.get('filter_criteria', [])
+            if isinstance(c, dict) and c.get('method') in ('above', 'below')
+        ]
+        if flagged:
+            self.logger.warning(
+                f"DEPRECATION: the 'method' (above/below) field in the structure-analysis "
+                f"JSON is no longer used by the m-fold sampling/voting workflow and can be "
+                f"removed. It is ignored here for criteria: {', '.join(flagged)}. "
+                f"(divide_and_conquer still uses 'method', so keep it in JSON configs "
+                f"shared with that workflow.)"
+            )
+
     def _init_slurm_submitter(self) -> SlurmJobSubmitter:
         """Initialize SLURM job submitter with configuration parameters"""
         return SlurmJobSubmitter(
@@ -605,6 +635,64 @@ class AFClaSeqPipeline:
             self.logger.error(f"Error in sequence voting: {str(e)}", exc_info=True)
             return False
     
+    def _resolve_recompile_bins(self, criterion_name: str, mbc: Optional[MetricBinConfig]) -> Tuple[List[int], bool, str]:
+        """Resolve which bins to recompile for one metric.
+
+        Returns ``(bin_numbers, combine_bins, description)``.
+
+        A metric threshold (``recompile_predict.threshold_N`` + ``threshold_direction_N``),
+        when set for this metric, OVERRIDES the explicit ``bin_numbers_N``: it selects
+        every bin whose entire range is on the reference side of the cutoff (via
+        ``MetricBinConfig.bins_within_threshold``) and forces those bins to be pooled into
+        one combined set (``combine_bins=True``), written as ``bin_<i>_<j>_...``. With no
+        threshold, the explicit ``bin_numbers_N`` are used with the global ``combine_bins``
+        flag — fully backward compatible.
+
+        Raises:
+            ValueError: threshold set without a direction, or without a usable
+                ``metric_bin_configs`` entry for this metric.
+        """
+        rp = self.config.recompile_predict
+        # Match this criterion to a slot exactly as the original bin_numbers logic did
+        # (metric_name_1 takes precedence over metric_name_2).
+        if criterion_name == rp.metric_name_1:
+            threshold, direction, explicit_bins = rp.threshold_1, rp.threshold_direction_1, rp.bin_numbers_1
+        elif criterion_name == rp.metric_name_2:
+            threshold, direction, explicit_bins = rp.threshold_2, rp.threshold_direction_2, rp.bin_numbers_2
+        else:
+            self.logger.warning(
+                f"'{criterion_name}' matches neither metric_name_1 nor metric_name_2; "
+                f"falling back to slot 1 (threshold_1/bin_numbers_1)."
+            )
+            threshold, direction, explicit_bins = rp.threshold_1, rp.threshold_direction_1, rp.bin_numbers_1
+
+        # bin_numbers may be a bare int (config allows Union[List[int], int]).
+        if isinstance(explicit_bins, int):
+            explicit_bins = [explicit_bins]
+
+        if threshold is not None:
+            if direction is None:
+                raise ValueError(
+                    f"threshold set for '{criterion_name}' but threshold_direction is "
+                    f"missing — specify 'below' or 'above'."
+                )
+            if mbc is None or mbc.bin_width is None:
+                raise ValueError(
+                    f"threshold-based recompile for '{criterion_name}' requires "
+                    f"general.metric_bin_configs['{criterion_name}'] with bin_width/min/max."
+                )
+            if explicit_bins:
+                self.logger.warning(
+                    f"Both threshold ({threshold}) and bin_numbers ({explicit_bins}) set "
+                    f"for '{criterion_name}'; using the threshold and ignoring bin_numbers."
+                )
+            focused = self.config.sequence_voting.use_focused_bins
+            bins = mbc.bins_within_threshold(threshold, direction, focused)
+            return bins, True, f"threshold {direction} {threshold} (focused={focused})"
+
+        # No threshold → original explicit-bin behavior.
+        return explicit_bins, rp.combine_bins, f"explicit bin_numbers {explicit_bins}"
+
     def run_recompile_and_predict(self) -> bool:
         """
         Stage 03: Recompile sequences and run structure prediction
@@ -663,26 +751,38 @@ class AFClaSeqPipeline:
                     all_successful = False
                     continue
 
-                # Determine bin numbers by matching metric name
-                bin_numbers = None
-                if criterion_name == self.config.recompile_predict.metric_name_1:
-                    bin_numbers = self.config.recompile_predict.bin_numbers_1
-                elif criterion_name == self.config.recompile_predict.metric_name_2:
-                    bin_numbers = self.config.recompile_predict.bin_numbers_2
-                else:
-                    # Fallback to bin_numbers_1
-                    self.logger.warning(f"No bin numbers specified for '{criterion_name}', using bin_numbers_1")
-                    bin_numbers = self.config.recompile_predict.bin_numbers_1
+                # Determine total bin count / bin edges from config (used for both the
+                # heatmap x-axis and the threshold-based bin selection below).
+                from af_claseq.m_fold_sampling_voting.config import get_metric_bin_config
+                mbc = get_metric_bin_config(self.config.general, criterion_name)
 
-                # If bin_numbers not specified, report error and skip this criterion
-                if not bin_numbers:
-                    self.logger.error(f"No bin numbers specified for criterion: {criterion_name}. Please specify bin_numbers_1 in the recompile_predict section of your configuration file.")
+                # Resolve which bins to recompile. A metric threshold (new) takes
+                # precedence over explicit bin_numbers (back-compat); see
+                # _resolve_recompile_bins.
+                try:
+                    bin_numbers, combine_bins, selection_desc = self._resolve_recompile_bins(
+                        criterion_name, mbc
+                    )
+                except ValueError as e:
+                    self.logger.error(f"Recompile selection failed for '{criterion_name}': {e}")
                     all_successful = False
                     continue
 
-                # Determine total bin count from config
-                from af_claseq.m_fold_sampling_voting.config import get_metric_bin_config
-                mbc = get_metric_bin_config(self.config.general, criterion_name)
+                # If no bins were selected, report error and skip this criterion.
+                if not bin_numbers:
+                    self.logger.error(
+                        f"No bins selected for criterion '{criterion_name}' ({selection_desc}). "
+                        f"Specify recompile_predict.bin_numbers_* or threshold_* (use a "
+                        f"coarser cutoff if a threshold selected zero bins)."
+                    )
+                    all_successful = False
+                    continue
+
+                self.logger.info(
+                    f"Recompile selection for '{criterion_name}': {selection_desc} "
+                    f"-> bins {bin_numbers} (combine_bins={combine_bins})"
+                )
+
                 if mbc is not None and mbc.bin_width is not None:
                     actual_num_bins = mbc.compute_num_bins()
                 else:
@@ -698,7 +798,7 @@ class AFClaSeqPipeline:
                     bin_numbers=bin_numbers,
                     num_total_bins=actual_num_bins,
                     initial_color=colors[0],
-                    combine_bins=self.config.recompile_predict.combine_bins,
+                    combine_bins=combine_bins,
                     raw_votes_json=raw_votes_json if raw_votes_json.exists() else None,
                     logger=self.logger,
                     default_pdb=self.config.general.default_pdb
@@ -711,7 +811,7 @@ class AFClaSeqPipeline:
                 prediction_config = {
                     'pure_seq_pred_base_dir': criterion_output_dir,
                     'bin_numbers': bin_numbers,
-                    'combine_bins': self.config.recompile_predict.combine_bins,
+                    'combine_bins': combine_bins,
                     'conda_env_path': self.config.slurm.conda_env_path,
                     'slurm_account': self.config.slurm.slurm_account,
                     'slurm_output': self.config.slurm.slurm_output,

--- a/src/af_claseq/m_fold_sampling_voting/config.py
+++ b/src/af_claseq/m_fold_sampling_voting/config.py
@@ -42,6 +42,65 @@ class MetricBinConfig:
             return None
         return max(1, math.ceil((self.max - self.min) / self.bin_width))
 
+    def bins_within_threshold(self, threshold: float, direction: str, focused: bool) -> List[int]:
+        """Return the bin indices whose ENTIRE value range lies on the reference
+        side of ``threshold`` (the "fully-below"/"fully-above" rule used by the
+        threshold-based recompile selection).
+
+        Args:
+            threshold: the metric cutoff value.
+            direction: ``"below"`` selects bins whose values are below the cutoff
+                (RMSD-/distance-like, lower = closer to the reference); ``"above"``
+                selects bins whose values are above the cutoff (TM-score-/distance-like,
+                higher = closer).
+            focused: must match the voting stage's ``use_focused_bins`` so the returned
+                indices line up with ``voting_results.csv``'s ``Bin_Assignment`` column:
+                  * ``True``  -> 1-based bins ``1..n`` plus sentinel ``0`` (values below
+                    ``min``) / ``n+1`` (values at or above ``max``);
+                  * ``False`` -> 0-based bins ``0..n-1`` (out-of-range values are clamped
+                    into the edge bins).
+
+        Returns:
+            Sorted list of qualifying bin indices. May be empty when the cutoff falls
+            inside the first/last bin so that no bin is wholly on the reference side.
+
+        Raises:
+            ValueError: if ``bin_width``/``min``/``max`` are unset, or ``direction`` is
+                not ``"below"``/``"above"``.
+        """
+        if self.bin_width is None or self.min is None or self.max is None:
+            raise ValueError(
+                "bins_within_threshold requires bin_width, min and max to be set; "
+                "define general.metric_bin_configs for this metric."
+            )
+        if direction not in ("below", "above"):
+            raise ValueError(f"direction must be 'below' or 'above', got {direction!r}")
+
+        n = self.compute_num_bins()
+        # Edge k (k = 0..n) — identical to np.linspace(min, max, n+1) used by the binners.
+        span = self.max - self.min
+        edges = [self.min + k * span / n for k in range(n + 1)]
+
+        # In-range bin k covers [edges[k], edges[k+1]); the voting stage numbers it k
+        # (0-based, non-focused) or k+1 (1-based, focused).
+        offset = 1 if focused else 0
+        selected: List[int] = []
+        for k in range(n):
+            left, right = edges[k], edges[k + 1]
+            if direction == "below" and right <= threshold:
+                selected.append(k + offset)
+            elif direction == "above" and left >= threshold:
+                selected.append(k + offset)
+
+        # Focused mode also has sentinel bins for out-of-range values.
+        if focused:
+            if direction == "below" and self.min <= threshold:
+                selected.append(0)      # sentinel: values below min
+            elif direction == "above" and self.max >= threshold:
+                selected.append(n + 1)  # sentinel: values at/above max
+
+        return sorted(selected)
+
 @dataclass
 class GeneralConfig:
     """General configuration options"""
@@ -146,6 +205,31 @@ class RecompilePredictConfig:
     # If ["bound_rmsd"] → only process that metric
     # If ["bound_rmsd", "apo_rmsd"] → process both
     metrics_to_process: Optional[List[str]] = None
+
+    # NEW: metric-threshold-based bin selection (alternative to explicit bin_numbers_*).
+    # When threshold_N is set for metric_name_N, the recompile stage selects every bin
+    # whose entire range is on the reference side of the cutoff (the "fully-below"/
+    # "fully-above" rule) and pools them into one combined set. Direction is explicit and
+    # NOT auto-derived from the metric type, because the same metric can define two
+    # opposite states (e.g. a distance: state A as dist > X, state B as dist < Y):
+    #   "below" = reference-like below the cutoff (RMSD-/distance-like)
+    #   "above" = reference-like above the cutoff (TM-score-/distance-like)
+    # threshold_N overrides bin_numbers_N when both are set. Leave threshold_N as None to
+    # keep the original explicit-bin behavior (fully backward compatible). Threshold mode
+    # requires general.metric_bin_configs[<metric>] (bin_width/min/max).
+    threshold_1: Optional[float] = None
+    threshold_2: Optional[float] = None
+    threshold_direction_1: Optional[str] = None  # "below" | "above"
+    threshold_direction_2: Optional[str] = None  # "below" | "above"
+
+    def __post_init__(self):
+        # Validate threshold directions at config-load time (mirrors MetricBinConfig).
+        for suffix, value in (("1", self.threshold_direction_1),
+                              ("2", self.threshold_direction_2)):
+            if value is not None and value not in ("below", "above"):
+                raise ValueError(
+                    f"threshold_direction_{suffix} must be 'below' or 'above', got {value!r}"
+                )
 
 @dataclass
 class PureSequencePlottingConfig:

--- a/tests/test_recompile_threshold_bins.py
+++ b/tests/test_recompile_threshold_bins.py
@@ -1,0 +1,101 @@
+"""Tests for the metric-threshold-based recompile bin selection
+(``MetricBinConfig.bins_within_threshold``) added on feat-recompile-metric-threshold.
+
+The selection uses the "fully-below"/"fully-above" rule: a bin qualifies only when its
+ENTIRE value range lies on the reference side of the cutoff. Returned indices must match
+the voting stage's convention (focused -> 1-based + sentinels; non-focused -> 0-based).
+"""
+
+import pytest
+
+from af_claseq.m_fold_sampling_voting.config import (
+    MetricBinConfig,
+    RecompilePredictConfig,
+)
+
+# AdK-style RMSD binning: bin_width 0.2, range 0..8 -> 40 bins, edge k = 0.2*k.
+RMSD = dict(bin_width=0.2, min=0.0, max=8.0)
+# TM-score-style binning: bin_width 0.02, range 0..1 -> 50 bins, edge k = 0.02*k.
+TM = dict(bin_width=0.02, min=0.0, max=1.0)
+
+
+@pytest.mark.parametrize("cfg,threshold,direction,focused,expected", [
+    # RMSD < 2.0 -> bins covering [0, 2.0): non-focused 0..9, focused 1..10 (+ sentinel 0).
+    (RMSD, 2.0, "below", False, list(range(0, 10))),
+    (RMSD, 2.0, "below", True,  [0] + list(range(1, 11))),
+    # TM > 0.9 -> bins covering [0.90, 1.00): non-focused 45..49, focused 46..50 (+ sentinel 51).
+    (TM,   0.9, "above", False, list(range(45, 50))),
+    (TM,   0.9, "above", True,  list(range(46, 51)) + [51]),
+])
+def test_bins_exact_edge(cfg, threshold, direction, focused, expected):
+    """Cutoff lands exactly on a bin edge — every option agrees on the boundary."""
+    assert MetricBinConfig(**cfg).bins_within_threshold(threshold, direction, focused) == expected
+
+
+class TestStraddleAndEmpty:
+    def test_straddling_bin_excluded_below(self):
+        # RMSD < 1.95: the bin [1.8, 2.0) straddles the cutoff and must be excluded.
+        bins = MetricBinConfig(**RMSD).bins_within_threshold(1.95, "below", focused=False)
+        assert bins == list(range(0, 9))  # bins 0..8 cover [0, 1.8)
+        assert 9 not in bins
+
+    def test_straddling_bin_excluded_above(self):
+        # TM > 0.91: bin [0.90, 0.92) straddles -> excluded; first fully-above is [0.92, 0.94).
+        bins = MetricBinConfig(**TM).bins_within_threshold(0.91, "above", focused=False)
+        assert min(bins) == 46  # left edge 0.92
+        assert 45 not in bins
+
+    def test_empty_when_cutoff_inside_first_bin_below(self):
+        # RMSD < 0.1 is inside bin 0 [0, 0.2): no bin is wholly below -> empty (non-focused).
+        bins = MetricBinConfig(**RMSD).bins_within_threshold(0.1, "below", focused=False)
+        assert bins == []
+
+    def test_empty_when_cutoff_inside_last_bin_above(self):
+        # TM > 0.99 is inside the last bin [0.98, 1.00): no bin wholly above -> empty (non-focused).
+        bins = MetricBinConfig(**TM).bins_within_threshold(0.99, "above", focused=False)
+        assert bins == []
+
+    def test_focused_only_sentinel_when_cutoff_inside_first_bin(self):
+        # Non-focused gives [] (no in-range bin qualifies); focused gives [0] (below-min sentinel).
+        bins = MetricBinConfig(**RMSD).bins_within_threshold(0.1, "below", focused=True)
+        assert bins == [0]
+
+
+class TestConventionRelationship:
+    def test_focused_offset_by_one_vs_nonfocused(self):
+        # The two conventions differ by exactly +1 on the in-range bins.
+        nf = MetricBinConfig(**RMSD).bins_within_threshold(2.0, "below", focused=False)
+        f = MetricBinConfig(**RMSD).bins_within_threshold(2.0, "below", focused=True)
+        f_inrange = [b for b in f if b != 0]
+        assert f_inrange == [b + 1 for b in nf]
+
+
+class TestBinsWithinThresholdErrors:
+    def test_requires_bin_width(self):
+        with pytest.raises(ValueError):
+            MetricBinConfig().bins_within_threshold(2.0, "below", focused=False)
+
+    def test_bad_direction(self):
+        with pytest.raises(ValueError):
+            MetricBinConfig(**RMSD).bins_within_threshold(2.0, "sideways", focused=False)
+
+
+class TestRecompileConfigBackCompat:
+    def test_new_threshold_fields_default_none(self):
+        # Threshold fields are additive and optional -> existing configs are unchanged.
+        cfg = RecompilePredictConfig(bin_numbers_1=[26], metric_name_1="m1")
+        assert cfg.threshold_1 is None
+        assert cfg.threshold_direction_1 is None
+        assert cfg.bin_numbers_1 == [26]
+
+    def test_threshold_fields_accepted(self):
+        cfg = RecompilePredictConfig(
+            metric_name_1="m1", threshold_1=2.0, threshold_direction_1="below"
+        )
+        assert cfg.threshold_1 == 2.0
+        assert cfg.threshold_direction_1 == "below"
+
+    def test_invalid_direction_rejected_at_construction(self):
+        # __post_init__ validates threshold_direction_* at config-load time.
+        with pytest.raises(ValueError):
+            RecompilePredictConfig(threshold_direction_1="bellow")


### PR DESCRIPTION
## What & why

In the `m_fold_sampling_voting` **recompile stage** you currently hand-pick bins via `recompile_predict.bin_numbers_1/2`. This PR adds the option to instead specify a **structural-metric cutoff** (e.g. `RMSD < 2.0 Å`, `TM-score > 0.9`) and have the driver automatically collect every qualifying bin — the "principled *similar-enough* CV cutoff" logged as future work in the method notes.

Closes #49.

## Behavior (all confirmed with the author)

- **Fully-below rule:** a bin is selected only when its *entire* range is on the reference side of the cutoff (a bin straddling the cutoff is excluded).
- **Pool into one set:** qualifying bins are unioned into a single purified MSA + one random control, written under an explicit `bin_<i>_<j>_...` directory and predicted 5×8. Threshold mode forces this pooling.
- **Direction is explicit** (`threshold_direction_* : "below" | "above"`), *not* auto-derived — so the same metric can define two opposite states (e.g. a distance: state A `> X`, state B `< Y`). Validated at config-load time.
- **Backward compatible:** with no `threshold_N` set, the stage behaves exactly as before (`bin_numbers_N`, honoring the global `combine_bins`).

```yaml
recompile_predict:
  metric_name_1: "bound_rmsd"
  threshold_1: 2.0
  threshold_direction_1: "below"     # RMSD-like
  metric_name_2: "open_tmscore"
  threshold_2: 0.9
  threshold_direction_2: "above"     # TM-like
```

## Deprecation (warn, never error)

The structure-analysis JSON's `"method": above|below` is dead in the m-fold path (direction is now explicit here, and m-fold never read it). The pipeline emits a one-time **deprecation warning** at startup when it's present, then continues. It is deliberately **not** removed and stays functional for `divide_and_conquer` (`apply_filters`) and the legacy `method == "all_atom_rmsd"` type alias; the warning fires only for `above`/`below`.

## Implementation

- `MetricBinConfig.bins_within_threshold(threshold, direction, focused)` — pure bin-edge math matching the voting stage's index convention (focused → 1-based + sentinels; non-focused → 0-based). `SequenceRecompiler` is untouched.
- `RecompilePredictConfig`: +`threshold_1/2`, +`threshold_direction_1/2`, +`__post_init__` validation.
- Driver: `_resolve_recompile_bins()` (slot-matching + threshold→bins + force-pool) and `_warn_deprecated_method_field()`.

## Tests

`tests/test_recompile_threshold_bins.py` — 15 unit tests (both index conventions, both directions, cutoff-on-edge, straddling-bin-excluded, empty result, focused sentinel, offset-by-one, error/validation cases, back-compat). **Full suite: 62 passed, 0 failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRYthRXcyXqDmp9j8Zxnvv
